### PR TITLE
Performance analysis and improvements

### DIFF
--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -5,6 +5,8 @@ Classes and functions related to matches
 """
 from collections import defaultdict, MutableSequence
 import copy
+import itertools
+
 try:
     from collections import OrderedDict  # pylint:disable=ungrouped-imports
 except ImportError:  # pragma: no cover
@@ -20,6 +22,7 @@ class MatchesDict(OrderedDict):
     """
     A custom dict with matches property.
     """
+
     def __init__(self):
         super(MatchesDict, self).__init__()
         self.matches = defaultdict(list)
@@ -33,18 +36,66 @@ class _BaseMatches(MutableSequence):
     _base = list
     _base_add = _base.append
     _base_remove = _base.remove
+    _base_extend = _base.extend
 
     def __init__(self, matches=None, input_string=None):
         self.input_string = input_string
         self._max_end = 0
         self._delegate = []
-        self._name_dict = defaultdict(_BaseMatches._base)
-        self._tag_dict = defaultdict(_BaseMatches._base)
-        self._start_dict = defaultdict(_BaseMatches._base)
-        self._end_dict = defaultdict(_BaseMatches._base)
-        self._index_dict = defaultdict(_BaseMatches._base)
+        self.__name_dict = None
+        self.__tag_dict = None
+        self.__start_dict = None
+        self.__end_dict = None
+        self.__index_dict = None
         if matches:
             self.extend(matches)
+
+    @property
+    def _name_dict(self):
+        if self.__name_dict is None:
+            self.__name_dict = defaultdict(_BaseMatches._base)
+            for name, values in itertools.groupby([m for m in self._delegate if m.name], lambda item: item.name):
+                _BaseMatches._base_extend(self.__name_dict[name], values)
+
+        return self.__name_dict
+
+    @property
+    def _start_dict(self):
+        if self.__start_dict is None:
+            self.__start_dict = defaultdict(_BaseMatches._base)
+            for start, values in itertools.groupby([m for m in self._delegate], lambda item: item.start):
+                _BaseMatches._base_extend(self.__start_dict[start], values)
+
+        return self.__start_dict
+
+    @property
+    def _end_dict(self):
+        if self.__end_dict is None:
+            self.__end_dict = defaultdict(_BaseMatches._base)
+            for start, values in itertools.groupby([m for m in self._delegate], lambda item: item.end):
+                _BaseMatches._base_extend(self.__end_dict[start], values)
+
+        return self.__end_dict
+
+    @property
+    def _tag_dict(self):
+        if self.__tag_dict is None:
+            self.__tag_dict = defaultdict(_BaseMatches._base)
+            for match in self._delegate:
+                for tag in match.tags:
+                    _BaseMatches._base_add(self.__tag_dict[tag], match)
+
+        return self.__tag_dict
+
+    @property
+    def _index_dict(self):
+        if self.__index_dict is None:
+            self.__index_dict = defaultdict(_BaseMatches._base)
+            for match in self._delegate:
+                for index in range(*match.span):
+                    _BaseMatches._base_add(self.__index_dict[index], match)
+
+        return self.__index_dict
 
     def _add_match(self, match):
         """
@@ -52,14 +103,19 @@ class _BaseMatches(MutableSequence):
         :param match:
         :type match: Match
         """
-        if match.name:
-            _BaseMatches._base_add(self._name_dict[match.name], (match))
-        for tag in match.tags:
-            _BaseMatches._base_add(self._tag_dict[tag], match)
-        _BaseMatches._base_add(self._start_dict[match.start], match)
-        _BaseMatches._base_add(self._end_dict[match.end], match)
-        for index in range(*match.span):
-            _BaseMatches._base_add(self._index_dict[index], match)
+        if self.__name_dict is not None:
+            if match.name:
+                _BaseMatches._base_add(self._name_dict[match.name], (match))
+        if self.__tag_dict is not None:
+            for tag in match.tags:
+                _BaseMatches._base_add(self._tag_dict[tag], match)
+        if self.__start_dict is not None:
+            _BaseMatches._base_add(self._start_dict[match.start], match)
+        if self.__end_dict is not None:
+            _BaseMatches._base_add(self._end_dict[match.end], match)
+        if self.__index_dict is not None:
+            for index in range(*match.span):
+                _BaseMatches._base_add(self._index_dict[index], match)
         if match.end > self._max_end:
             self._max_end = match.end
 
@@ -69,14 +125,19 @@ class _BaseMatches(MutableSequence):
         :param match:
         :type match: Match
         """
-        if match.name:
-            _BaseMatches._base_remove(self._name_dict[match.name], match)
-        for tag in match.tags:
-            _BaseMatches._base_remove(self._tag_dict[tag], match)
-        _BaseMatches._base_remove(self._start_dict[match.start], match)
-        _BaseMatches._base_remove(self._end_dict[match.end], match)
-        for index in range(*match.span):
-            _BaseMatches._base_remove(self._index_dict[index], match)
+        if self.__name_dict is not None:
+            if match.name:
+                _BaseMatches._base_remove(self._name_dict[match.name], match)
+        if self.__tag_dict is not None:
+            for tag in match.tags:
+                _BaseMatches._base_remove(self._tag_dict[tag], match)
+        if self.__start_dict is not None:
+            _BaseMatches._base_remove(self._start_dict[match.start], match)
+        if self.__end_dict is not None:
+            _BaseMatches._base_remove(self._end_dict[match.end], match)
+        if self.__index_dict is not None:
+            for index in range(*match.span):
+                _BaseMatches._base_remove(self._index_dict[index], match)
         if match.end >= self._max_end and not self._end_dict[match.end]:
             self._max_end = max(self._end_dict.keys())
 
@@ -311,7 +372,8 @@ class _BaseMatches(MutableSequence):
                     return rindex
         return self.max_end
 
-    def holes(self, start=0, end=None, formatter=None, ignore=None, seps=None, predicate=None, index=None):  # pylint: disable=too-many-branches,too-many-locals
+    def holes(self, start=0, end=None, formatter=None, ignore=None, seps=None, predicate=None,
+              index=None):  # pylint: disable=too-many-branches,too-many-locals
         """
         Retrieves a set of Match objects that are not defined in given range.
         :param start:
@@ -508,6 +570,7 @@ class Matches(_BaseMatches):
     """
     A custom list[Match] contains matches list.
     """
+
     def __init__(self, matches=None, input_string=None):
         self.markers = Markers(input_string=input_string)
         super(Matches, self).__init__(matches=matches, input_string=input_string)
@@ -521,6 +584,7 @@ class Markers(_BaseMatches):
     """
     A custom list[Match] containing markers list.
     """
+
     def __init__(self, matches=None, input_string=None):
         super(Markers, self).__init__(matches=None, input_string=input_string)
 
@@ -533,8 +597,9 @@ class Match(object):
     """
     Object storing values related to a single match
     """
+
     def __init__(self, start, end, value=None, name=None, tags=None, marker=None, parent=None, private=None,
-                 pattern=None, input_string=None, formatter=None, conflict_solver=None):
+                 pattern=None, input_string=None, formatter=None, conflict_solver=None, **kwargs):
         self.start = start
         self.end = end
         self.name = name
@@ -547,7 +612,7 @@ class Match(object):
         self.pattern = pattern
         self.private = private
         self.conflict_solver = conflict_solver
-        self.children = Matches([], input_string)
+        self._children = None
         self._raw_start = None
         self._raw_end = None
         self.defined_at = pattern.defined_at if pattern else defined_at()
@@ -558,6 +623,19 @@ class Match(object):
         2-tuple with start and end indices of the match
         """
         return self.start, self.end
+
+    @property
+    def children(self):
+        """
+        Children matches.
+        """
+        if self._children is None:
+            self._children = Matches(None, self.input_string)
+        return self._children
+
+    @children.setter
+    def children(self, value):
+        self._children = value
 
     @property
     def value(self):
@@ -736,13 +814,13 @@ class Match(object):
     def __eq__(self, other):
         if isinstance(other, Match):
             return self.span == other.span and self.value == other.value and self.name == other.name and \
-                self.parent == other.parent
+                   self.parent == other.parent
         return NotImplemented
 
     def __ne__(self, other):
         if isinstance(other, Match):
             return self.span != other.span or self.value != other.value or self.name != other.name or \
-                self.parent != other.parent
+                   self.parent != other.parent
         return NotImplemented
 
     def __lt__(self, other):

--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -600,6 +600,7 @@ class Match(object):
 
     def __init__(self, start, end, value=None, name=None, tags=None, marker=None, parent=None, private=None,
                  pattern=None, input_string=None, formatter=None, conflict_solver=None, **kwargs):
+        _ = kwargs
         self.start = start
         self.end = end
         self.name = name

--- a/rebulk/pattern.py
+++ b/rebulk/pattern.py
@@ -70,6 +70,7 @@ class Pattern(object):
         :type post_processor: func
         """
         # pylint:disable=too-many-locals
+        _ = kwargs
         self.name = name
         self.tags = ensure_list(tags)
         self.formatters, self._default_formatter = ensure_dict(formatter, lambda x: x)

--- a/rebulk/pattern.py
+++ b/rebulk/pattern.py
@@ -25,7 +25,7 @@ class Pattern(object):
     def __init__(self, name=None, tags=None, formatter=None, value=None, validator=None, children=False, every=False,
                  private_parent=False, private_children=False, private=False, private_names=None, ignore_names=None,
                  marker=False, format_all=False, validate_all=False, disabled=lambda context: False, log_level=None,
-                 properties=None, post_processor=None):
+                 properties=None, post_processor=None, **kwargs):
         """
         :param name: Name of this pattern
         :type name: str
@@ -136,7 +136,7 @@ class Pattern(object):
         :return:
         :rtype:
         """
-        if len(match) < 0 or match.value == "":
+        if len(match) == 0 or match.value == "":
             return False
 
         pattern_value = get_first_defined(self.values, [match.name, '__parent__', None],
@@ -164,7 +164,7 @@ class Pattern(object):
         :return:
         :rtype:
         """
-        if len(child) < 0 or child.value == "":
+        if len(child) == 0 or child.value == "":
             return False
 
         pattern_value = get_first_defined(self.values, [child.name, '__children__', None],
@@ -243,7 +243,7 @@ class Pattern(object):
         :rtype:
         """
         if self.post_processor:
-            return call(self.post_processor, matches, self)
+            return self.post_processor(matches, self)
         return matches
 
     def _matches_privatize(self, matches):
@@ -335,7 +335,7 @@ class StringPattern(Pattern):
     """
 
     def __init__(self, *patterns, **kwargs):
-        call(super(StringPattern, self).__init__, **kwargs)
+        super(StringPattern, self).__init__(**kwargs)
         self._patterns = patterns
         self._kwargs = kwargs
         self._match_kwargs = filter_match_kwargs(kwargs)
@@ -349,9 +349,8 @@ class StringPattern(Pattern):
         return self._match_kwargs
 
     def _match(self, pattern, input_string, context=None):
-        for index in call(find_all, input_string, pattern, **self._kwargs):
-            yield call(Match, index, index + len(pattern), pattern=self, input_string=input_string,
-                       **self._match_kwargs)
+        for index in find_all(input_string, pattern, **self._kwargs):
+            yield Match(index, index + len(pattern), pattern=self, input_string=input_string, **self._match_kwargs)
 
 
 class RePattern(Pattern):
@@ -360,7 +359,7 @@ class RePattern(Pattern):
     """
 
     def __init__(self, *patterns, **kwargs):
-        call(super(RePattern, self).__init__, **kwargs)
+        super(RePattern, self).__init__(**kwargs)
         self.repeated_captures = REGEX_AVAILABLE
         if 'repeated_captures' in kwargs:
             self.repeated_captures = kwargs.get('repeated_captures')
@@ -403,21 +402,21 @@ class RePattern(Pattern):
         for match_object in pattern.finditer(input_string):
             start = match_object.start()
             end = match_object.end()
-            main_match = call(Match, start, end, pattern=self, input_string=input_string, **self._match_kwargs)
+            main_match = Match(start, end, pattern=self, input_string=input_string, **self._match_kwargs)
 
             if pattern.groups:
                 for i in range(1, pattern.groups + 1):
                     name = names.get(i, main_match.name)
                     if self.repeated_captures:
                         for start, end in match_object.spans(i):
-                            child_match = call(Match, start, end, name=name, parent=main_match, pattern=self,
-                                               input_string=input_string, **self._children_match_kwargs)
+                            child_match = Match(start, end, name=name, parent=main_match, pattern=self,
+                                                input_string=input_string, **self._children_match_kwargs)
                             main_match.children.append(child_match)
                     else:
                         start, end = match_object.span(i)
                         if start > -1 and end > -1:
-                            child_match = call(Match, start, end, name=name, parent=main_match, pattern=self,
-                                               input_string=input_string, **self._children_match_kwargs)
+                            child_match = Match(start, end, name=name, parent=main_match, pattern=self,
+                                                input_string=input_string, **self._children_match_kwargs)
                             main_match.children.append(child_match)
 
             yield main_match
@@ -429,7 +428,7 @@ class FunctionalPattern(Pattern):
     """
 
     def __init__(self, *patterns, **kwargs):
-        call(super(FunctionalPattern, self).__init__, **kwargs)
+        super(FunctionalPattern, self).__init__(**kwargs)
         self._patterns = patterns
         self._kwargs = kwargs
         self._match_kwargs = filter_match_kwargs(kwargs)
@@ -458,14 +457,14 @@ class FunctionalPattern(Pattern):
                     if self._match_kwargs:
                         options = self._match_kwargs.copy()
                         options.update(args)
-                    yield call(Match, pattern=self, input_string=input_string, **options)
+                    yield Match(pattern=self, input_string=input_string, **options)
                 else:
                     kwargs = self._match_kwargs
                     if isinstance(args[-1], dict):
                         kwargs = dict(kwargs)
                         kwargs.update(args[-1])
                         args = args[:-1]
-                    yield call(Match, *args, pattern=self, input_string=input_string, **kwargs)
+                    yield Match(*args, pattern=self, input_string=input_string, **kwargs)
 
 
 def filter_match_kwargs(kwargs, children=False):

--- a/rebulk/utils.py
+++ b/rebulk/utils.py
@@ -8,7 +8,7 @@ from collections import MutableSet
 from types import GeneratorType
 
 
-def find_all(string, sub, start=None, end=None, ignore_case=False):
+def find_all(string, sub, start=None, end=None, ignore_case=False, **kwargs):
     """
     Return all indices in string s where substring sub is
     found, such that sub is contained in the slice s[start:end].
@@ -65,10 +65,8 @@ def get_first_defined(data, keys, default_value=None):
     :rtype:
     """
     for key in keys:
-        try:
+        if key in data:
             return data[key]
-        except KeyError:
-            pass
     return default_value
 
 

--- a/rebulk/utils.py
+++ b/rebulk/utils.py
@@ -41,6 +41,7 @@ def find_all(string, sub, start=None, end=None, ignore_case=False, **kwargs):
     :return: all indices in the input string
     :rtype: __generator[str]
     """
+    _ = kwargs
     if ignore_case:
         sub = sub.lower()
         string = string.lower()


### PR DESCRIPTION
I've been profiling rebulk and guessit and I have some preliminary results that I could share.

My scenario is:
- Guessing 1000 different release names

I measured the time spent (before / after) and I also used `cProfile` and `line_profiler` to help me understand where most of the time was spent.

In my machine, for the current guessit version and current rebulk version:
> 1000 release names takes 37 seconds to be processed: `37ms per release name`

For the modified rebulk version:
> 1000 release names takes 22.5 seconds to be processed: `22ms per release name` (+36% faster)

The first hotspot was the usage of `call` to instantiate `Match` objects. Almost a million `Match` objects are created and every `call` execution was introspecting the valid `kwargs` to be used. Using `kwargs` instead of `call` reduced the total time from 37 seconds to 28.5 seconds (+23% faster).

The second hotspot is related to `Matches` instantiation (which happens several times for children matches). The `BaseMatch` contains a collection of dictionaries in order to fast access matches by index, name, tag, etc.
All these dictionaries are instantiated as soon as a `Matches` object is created and all of them are populated as soon as matches are added to it. I tried some `experimental` code to only instantiate and populate these dictionaries when they are first needed, since not all rules will access all dictionaries from all matches. That change reduced the total time from 28.5 seconds to 22.5 seconds (+21% faster).

I did run guessit test suite using these modifications as well another test suite that I have. All of them remain green

Hope this can be useful.