### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
   - 3.5
   - 3.6
   - pypy
+arch:
+    - amd64
+    - ppc64le
 matrix:
   include:
     - python: 3.7
@@ -12,6 +15,17 @@ matrix:
     - python: 3.8-dev
       dist: xenial
       sudo: true
+    - arch: ppc64le
+      python: 3.7
+      dist: xenial
+      sudo: true
+    - arch: ppc64le
+      python: 3.8-dev
+      dist: xenial
+      sudo: true
+  exclude: # Disable pypy version for power support
+    - arch: ppc64le
+      python: pypy
 env:
   matrix:
     - PYTHON_REGEX=false


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.