### PR TITLE
Optimize extend_safe function performance using set-based lookups

### DIFF
--- a/rebulk/utils.py
+++ b/rebulk/utils.py
@@ -95,9 +95,11 @@ def extend_safe(target, source):
     :param source:
     :type source: list
     """
+    target_set = set(target)
     for elt in source:
-        if elt not in target:
+        if elt not in target_set:
             target.append(elt)
+            target_set.add(elt)
 
 
 class _Ref:


### PR DESCRIPTION
## Description
This PR optimizes the `extend_safe` function by replacing linear searches with constant-time set lookups, reducing time complexity from O(n*m) to O(n+m).

## Changes
- Modified `extend_safe` to use a set for checking element existence
- Maintain a set copy of the target list to enable O(1) lookups
- Update the set as new elements are added to keep it in sync

## Performance Impact
- Before: O(n*m) where n = len(target) and m = len(source)
- After: O(n+m) with constant-time membership checks

## Testing
- Tested with various input sizes to verify correctness and performance improvement
- Maintains identical functionality while significantly improving execution time for large lists