### PR TITLE
Add sort  before `groupby`

### DIFF
--- a/rebulk/chain.py
+++ b/rebulk/chain.py
@@ -185,7 +185,7 @@ class Chain(Pattern, Builder):
     @staticmethod
     def _group_by_match_index(matches):
         grouped_matches_dict = {}
-        for match_index, match in itertools.groupby(matches, lambda m: m.match_index):
+        for match_index, match in itertools.groupby(sorted(matches, key=lambda m: m.match_index), lambda m: m.match_index):
             grouped_matches_dict[match_index] = list(match)
         return grouped_matches_dict
 

--- a/rebulk/test/test_chain.py
+++ b/rebulk/test/test_chain.py
@@ -7,6 +7,8 @@ from functools import partial
 from rebulk.pattern import FunctionalPattern, StringPattern, RePattern
 from ..rebulk import Rebulk
 from ..validators import chars_surround
+from ..chain import Chain
+from ..match import Match
 
 
 def test_chain_close():
@@ -459,3 +461,44 @@ def test_chain_breaker_defaults2():
     matches[0].value = 1
     matches[1].value = 2
     matches[2].value = 3
+
+
+def test_group_by_match_index_with_unsorted_data():
+    """
+    The groupby function requires pre-sorted data, so _group_by_match_index
+    must sort matches by match_index before grouping.
+    """
+    
+    # Create mock matches with unsorted match_index values
+    match1 = Match(0, 5, value='a', name='test')
+    match1.match_index = 2
+    
+    match2 = Match(6, 10, value='b', name='test')
+    match2.match_index = 0
+    
+    match3 = Match(11, 15, value='c', name='test')
+    match3.match_index = 1
+    
+    match4 = Match(16, 20, value='d', name='test')
+    match4.match_index = 2
+    
+    # Create unsorted matches list
+    unsorted_matches = [match1, match2, match3, match4]
+    
+    # Call _group_by_match_index with unsorted data
+    grouped = Chain._group_by_match_index(unsorted_matches)
+    
+    # Verify grouping is correct despite unsorted input
+    assert 0 in grouped
+    assert 1 in grouped
+    assert 2 in grouped
+    
+    assert len(grouped[0]) == 1
+    assert grouped[0][0] == match2
+    
+    assert len(grouped[1]) == 1
+    assert grouped[1][0] == match3
+    
+    assert len(grouped[2]) == 2
+    assert grouped[2][0] == match1
+    assert grouped[2][1] == match4


### PR DESCRIPTION
Hello! 

While reading the code and running some tests, I noticed a small detail that could cause unexpected behavior when the input list is not ordered. The `itertools.groupby()` function assumes the data is already sorted by the key ([docs](https://docs.python.org/3/library/itertools.html#itertools.groupby)), but in `_group_by_match_index` this was not guaranteed.

So I added a `sorted()` call before the `groupby()` to make the behavior safe and consistent, regardless of the input order. 

Interestingly, the rest of the codebase already follows this same pattern:

- [rules.py:300](rebulk/rules.py#L300) - Uses `sorted()` before `groupby()`
- [match.py:62](rebulk/match.py#L62) - Maintains proper ordering
- [match.py:71](rebulk/match.py#L71) - Maintains proper ordering

I also added a small test that explicitly checks the behavior with unsorted input data, just to make sure this case is always covered.

Thank youfor the project!
I hope this improvement is helpful.