### PR TITLE
feat(typing): precise return types for query methods via @overload

### DIFF
--- a/rebulk/chain.py
+++ b/rebulk/chain.py
@@ -251,11 +251,20 @@ class ChainPart(BasePattern):
     def _is_chain_start(self) -> bool:
         return self._chain.parts[0] == self
 
-    @overload  # type: ignore[override]
+    @overload
     def matches(
         self,
         input_string: str,
         context: dict[str, Any] | None,
+        with_raw_matches: Literal[True],
+    ) -> tuple[list[Match], list[Match]]: ...
+
+    @overload
+    def matches(
+        self,
+        input_string: str,
+        context: dict[str, Any] | None = ...,
+        *,
         with_raw_matches: Literal[True],
     ) -> tuple[list[Match], list[Match]]: ...
 

--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -140,6 +140,14 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
         if match.end >= self._max_end and not self._end_dict[match.end]:
             self._max_end = max(self._end_dict.keys())
 
+    @overload
+    def previous(self, match: Match, predicate: int) -> Match | None: ...
+    @overload
+    def previous(self, match: Match, predicate: Callable[[Match], Any] | None, index: int) -> Match | None: ...
+    @overload
+    def previous(self, match: Match, predicate: Callable[[Match], Any] | None = ..., *, index: int) -> Match | None: ...
+    @overload
+    def previous(self, match: Match, predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
     def previous(
         self, match: Match, predicate: Callable[[Match], Any] | int | None = None, index: int | None = None
     ) -> Any:
@@ -162,6 +170,14 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
             current -= 1
         return filter_index(_BaseMatches._base(), predicate, index)
 
+    @overload
+    def next(self, match: Match, predicate: int) -> Match | None: ...
+    @overload
+    def next(self, match: Match, predicate: Callable[[Match], Any] | None, index: int) -> Match | None: ...
+    @overload
+    def next(self, match: Match, predicate: Callable[[Match], Any] | None = ..., *, index: int) -> Match | None: ...
+    @overload
+    def next(self, match: Match, predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
     def next(
         self, match: Match, predicate: Callable[[Match], Any] | int | None = None, index: int | None = None
     ) -> Any:
@@ -184,6 +200,14 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
             current += 1
         return filter_index(_BaseMatches._base(), predicate, index)
 
+    @overload
+    def named(self, name: str, predicate: int) -> Match | None: ...
+    @overload
+    def named(self, name: str, predicate: Callable[[Match], Any] | None, index: int) -> Match | None: ...
+    @overload
+    def named(self, name: str, predicate: Callable[[Match], Any] | None = ..., *, index: int) -> Match | None: ...
+    @overload
+    def named(self, name: str, predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
     def named(self, name: str, predicate: Callable[[Match], Any] | int | None = None, index: int | None = None) -> Any:
         """
         Retrieves a set of Match objects that have the given name.
@@ -198,6 +222,14 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
         """
         return filter_index(_BaseMatches._base(self._name_dict[name]), predicate, index)
 
+    @overload
+    def tagged(self, tag: str, predicate: int) -> Match | None: ...
+    @overload
+    def tagged(self, tag: str, predicate: Callable[[Match], Any] | None, index: int) -> Match | None: ...
+    @overload
+    def tagged(self, tag: str, predicate: Callable[[Match], Any] | None = ..., *, index: int) -> Match | None: ...
+    @overload
+    def tagged(self, tag: str, predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
     def tagged(self, tag: str, predicate: Callable[[Match], Any] | int | None = None, index: int | None = None) -> Any:
         """
         Retrieves a set of Match objects that have the given tag defined.
@@ -212,6 +244,14 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
         """
         return filter_index(_BaseMatches._base(self._tag_dict[tag]), predicate, index)
 
+    @overload
+    def starting(self, start: int, predicate: int) -> Match | None: ...
+    @overload
+    def starting(self, start: int, predicate: Callable[[Match], Any] | None, index: int) -> Match | None: ...
+    @overload
+    def starting(self, start: int, predicate: Callable[[Match], Any] | None = ..., *, index: int) -> Match | None: ...
+    @overload
+    def starting(self, start: int, predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
     def starting(
         self, start: int, predicate: Callable[[Match], Any] | int | None = None, index: int | None = None
     ) -> Any:
@@ -228,6 +268,14 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
         """
         return filter_index(_BaseMatches._base(self._start_dict[start]), predicate, index)
 
+    @overload
+    def ending(self, end: int, predicate: int) -> Match | None: ...
+    @overload
+    def ending(self, end: int, predicate: Callable[[Match], Any] | None, index: int) -> Match | None: ...
+    @overload
+    def ending(self, end: int, predicate: Callable[[Match], Any] | None = ..., *, index: int) -> Match | None: ...
+    @overload
+    def ending(self, end: int, predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
     def ending(self, end: int, predicate: Callable[[Match], Any] | int | None = None, index: int | None = None) -> Any:
         """
         Retrieves a set of Match objects that ends at given index.
@@ -240,6 +288,25 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
         """
         return filter_index(_BaseMatches._base(self._end_dict[end]), predicate, index)
 
+    @overload
+    def range(self, start: int, end: int | None, predicate: int) -> Match | None: ...
+    @overload
+    def range(
+        self, start: int, end: int | None, predicate: Callable[[Match], Any] | None, index: int
+    ) -> Match | None: ...
+    @overload
+    def range(
+        self,
+        start: int = ...,
+        end: int | None = ...,
+        predicate: Callable[[Match], Any] | None = ...,
+        *,
+        index: int,
+    ) -> Match | None: ...
+    @overload
+    def range(
+        self, start: int = ..., end: int | None = ..., predicate: Callable[[Match], Any] | None = ...
+    ) -> list[Match]: ...
     def range(
         self,
         start: int = 0,
@@ -267,6 +334,20 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
                 ret.append(match)
         return filter_index(ret, predicate, index)
 
+    @overload
+    def chain_before(
+        self,
+        position: int | Match,
+        seps: str,
+        start: int = ...,
+        predicate: Callable[[Match], Any] | None = ...,
+        *,
+        index: int,
+    ) -> Match | None: ...
+    @overload
+    def chain_before(
+        self, position: int | Match, seps: str, start: int = ..., predicate: Callable[[Match], Any] | None = ...
+    ) -> list[Match]: ...
     def chain_before(
         self,
         position: int | Match,
@@ -309,6 +390,20 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
 
         return filter_index(chain, predicate, index)
 
+    @overload
+    def chain_after(
+        self,
+        position: int | Match,
+        seps: str,
+        end: int | None = ...,
+        predicate: Callable[[Match], Any] | None = ...,
+        *,
+        index: int,
+    ) -> Match | None: ...
+    @overload
+    def chain_after(
+        self, position: int | Match, seps: str, end: int | None = ..., predicate: Callable[[Match], Any] | None = ...
+    ) -> list[Match]: ...
     def chain_after(
         self,
         position: int | Match,
@@ -391,6 +486,28 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
                     return rindex
         return self.max_end
 
+    @overload
+    def holes(
+        self,
+        start: int = ...,
+        end: int | None = ...,
+        formatter: Any = ...,
+        ignore: Callable[[Match], Any] | None = ...,
+        seps: str | None = ...,
+        predicate: Callable[[Match], Any] | None = ...,
+        *,
+        index: int,
+    ) -> Match | None: ...
+    @overload
+    def holes(
+        self,
+        start: int = ...,
+        end: int | None = ...,
+        formatter: Any = ...,
+        ignore: Callable[[Match], Any] | None = ...,
+        seps: str | None = ...,
+        predicate: Callable[[Match], Any] | None = ...,
+    ) -> list[Match]: ...
     def holes(
         self,
         start: int = 0,
@@ -454,6 +571,16 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
             ret[-1].end = min(self._hole_end(rindex, ignore), end)
         return filter_index(ret, predicate, index)
 
+    @overload
+    def conflicting(self, match: Match, predicate: int) -> Match | None: ...
+    @overload
+    def conflicting(self, match: Match, predicate: Callable[[Match], Any] | None, index: int) -> Match | None: ...
+    @overload
+    def conflicting(
+        self, match: Match, predicate: Callable[[Match], Any] | None = ..., *, index: int
+    ) -> Match | None: ...
+    @overload
+    def conflicting(self, match: Match, predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
     def conflicting(
         self, match: Match, predicate: Callable[[Match], Any] | int | None = None, index: int | None = None
     ) -> Any:
@@ -479,14 +606,34 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
 
         return filter_index(ret, predicate, index)
 
+    @overload
+    def at_match(self, match: Match, predicate: int) -> Match | None: ...
+    @overload
+    def at_match(self, match: Match, predicate: Callable[[Match], Any] | None, index: int) -> Match | None: ...
+    @overload
+    def at_match(self, match: Match, predicate: Callable[[Match], Any] | None = ..., *, index: int) -> Match | None: ...
+    @overload
+    def at_match(self, match: Match, predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
     def at_match(
         self, match: Match, predicate: Callable[[Match], Any] | int | None = None, index: int | None = None
     ) -> Any:
         """
         Retrieves a list of matches from given match.
         """
-        return self.at_span(match.span, predicate, index)
+        # Delegating between overloaded methods: the loose impl-level union of
+        # predicate/index does not match any single public overload of at_span.
+        return self.at_span(match.span, predicate, index)  # type: ignore[arg-type]
 
+    @overload
+    def at_span(self, span: tuple[int, int], predicate: int) -> Match | None: ...
+    @overload
+    def at_span(self, span: tuple[int, int], predicate: Callable[[Match], Any] | None, index: int) -> Match | None: ...
+    @overload
+    def at_span(
+        self, span: tuple[int, int], predicate: Callable[[Match], Any] | None = ..., *, index: int
+    ) -> Match | None: ...
+    @overload
+    def at_span(self, span: tuple[int, int], predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
     def at_span(
         self,
         span: tuple[int, int],
@@ -506,6 +653,14 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
 
         return filter_index(merged, predicate, index)
 
+    @overload
+    def at_index(self, pos: int, predicate: int) -> Match | None: ...
+    @overload
+    def at_index(self, pos: int, predicate: Callable[[Match], Any] | None, index: int) -> Match | None: ...
+    @overload
+    def at_index(self, pos: int, predicate: Callable[[Match], Any] | None = ..., *, index: int) -> Match | None: ...
+    @overload
+    def at_index(self, pos: int, predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
     def at_index(
         self, pos: int, predicate: Callable[[Match], Any] | int | None = None, index: int | None = None
     ) -> Any:
@@ -805,6 +960,14 @@ class Match:
             match = match.parent
         return match
 
+    @overload
+    def crop(self, crops: Any, predicate: int) -> Match | None: ...
+    @overload
+    def crop(self, crops: Any, predicate: Callable[[Match], Any] | None, index: int) -> Match | None: ...
+    @overload
+    def crop(self, crops: Any, predicate: Callable[[Match], Any] | None = ..., *, index: int) -> Match | None: ...
+    @overload
+    def crop(self, crops: Any, predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
     def crop(
         self,
         crops: Any,
@@ -846,6 +1009,14 @@ class Match:
                     current.end = start
         return filter_index(ret, predicate, index)
 
+    @overload
+    def split(self, seps: str, predicate: int) -> Match | None: ...
+    @overload
+    def split(self, seps: str, predicate: Callable[[Match], Any] | None, index: int) -> Match | None: ...
+    @overload
+    def split(self, seps: str, predicate: Callable[[Match], Any] | None = ..., *, index: int) -> Match | None: ...
+    @overload
+    def split(self, seps: str, predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
     def split(
         self,
         seps: str,

--- a/rebulk/pattern.py
+++ b/rebulk/pattern.py
@@ -6,7 +6,7 @@ Abstract pattern class definition along with various implementations (regexp, st
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from . import debug
 from .formatters import default_formatter
@@ -25,25 +25,23 @@ class BasePattern(metaclass=ABCMeta):
     Base class for Pattern like objects
     """
 
+    # Computes all matches for a given input. When ``with_raw_matches`` is True, a
+    # ``(matches, raw_matches)`` tuple is returned, otherwise a plain list of matches.
+    @overload
     @abstractmethod
     def matches(
-        self,
-        input_string: str,
-        context: dict[str, Any] | None = None,
-        with_raw_matches: bool = False,
-    ) -> list[Match] | tuple[list[Match], list[Match]]:
-        """
-        Computes all matches for a given input
-
-        :param input_string: the string to parse
-        :type input_string: str
-        :param context: the context
-        :type context: dict
-        :param with_raw_matches: should return details
-        :type with_raw_matches: dict
-        :return: matches based on input_string for this pattern
-        :rtype: iterator[Match]
-        """
+        self, input_string: str, context: dict[str, Any] | None, with_raw_matches: Literal[True]
+    ) -> tuple[list[Match], list[Match]]: ...
+    @overload
+    @abstractmethod
+    def matches(
+        self, input_string: str, context: dict[str, Any] | None = ..., *, with_raw_matches: Literal[True]
+    ) -> tuple[list[Match], list[Match]]: ...
+    @overload
+    @abstractmethod
+    def matches(
+        self, input_string: str, context: dict[str, Any] | None = ..., with_raw_matches: Literal[False] = ...
+    ) -> list[Match]: ...
 
 
 class Pattern(BasePattern, metaclass=ABCMeta):
@@ -171,6 +169,18 @@ class Pattern(BasePattern, metaclass=ABCMeta):
         """
         return self._log_level if self._log_level is not None else debug.LOG_LEVEL
 
+    @overload
+    def matches(
+        self, input_string: str, context: dict[str, Any] | None, with_raw_matches: Literal[True]
+    ) -> tuple[list[Match], list[Match]]: ...
+    @overload
+    def matches(
+        self, input_string: str, context: dict[str, Any] | None = ..., *, with_raw_matches: Literal[True]
+    ) -> tuple[list[Match], list[Match]]: ...
+    @overload
+    def matches(
+        self, input_string: str, context: dict[str, Any] | None = ..., with_raw_matches: Literal[False] = ...
+    ) -> list[Match]: ...
     def matches(
         self,
         input_string: str,

--- a/rebulk/rebulk.py
+++ b/rebulk/rebulk.py
@@ -9,7 +9,7 @@ from logging import getLogger
 from typing import TYPE_CHECKING, Any, cast
 
 from .builder import Builder
-from .match import Match, Matches
+from .match import Matches
 from .processors import ConflictSolver, PrivateRemover
 from .rules import CustomRule, Rules
 from .utils import extend_safe
@@ -186,7 +186,7 @@ class Rebulk(Builder):
             patterns = self.effective_patterns(context)
             for pattern in patterns:
                 if not pattern.disabled(context):
-                    pattern_matches = cast("list[Match]", pattern.matches(cast("str", matches.input_string), context))
+                    pattern_matches = pattern.matches(cast("str", matches.input_string), context)
                     if pattern_matches:
                         log(pattern.log_level, "Pattern has %s match(es). (%s)", len(pattern_matches), pattern)
                     else:

--- a/rebulk/test/test_match.py
+++ b/rebulk/test/test_match.py
@@ -340,36 +340,38 @@ class TestMaches:
         assert selection[0].pattern.name == "1-str"
         assert selection[1].pattern.name == "1-re"
 
-        selection = matches.previous(matches.named("2-str", 0), lambda m: "str" in m.tags)
+        anchor = matches.named("2-str")[0]
+
+        selection = matches.previous(anchor, lambda m: "str" in m.tags)
         assert len(selection) == 1
         assert selection[0].pattern.name == "1-str"
 
-        selection = matches.next(matches.named("2-str", 0))
+        selection = matches.next(anchor)
         assert len(selection) == 2
         assert selection[0].pattern.name == "3-str"
         assert selection[1].pattern.name == "3-re"
 
-        selection = matches.next(matches.named("2-str", 0), index=0, predicate=lambda m: "re" in m.tags)
-        assert selection is not None
-        assert selection.pattern.name == "3-re"
+        single = matches.next(anchor, index=0, predicate=lambda m: "re" in m.tags)
+        assert single is not None
+        assert single.pattern.name == "3-re"
 
-        selection = matches.next(matches.named("2-str", index=0), lambda m: "re" in m.tags)
+        selection = matches.next(anchor, lambda m: "re" in m.tags)
         assert len(selection) == 1
         assert selection[0].pattern.name == "3-re"
 
         selection = matches.named("2-str", lambda m: "re" in m.tags)
         assert len(selection) == 0
 
-        selection = matches.named("2-re", lambda m: "re" in m.tags, 0)
-        assert selection is not None
-        assert selection.name == "2-re"
+        single = matches.named("2-re", lambda m: "re" in m.tags, 0)
+        assert single is not None
+        assert single.name == "2-re"
 
         selection = matches.named("2-re", lambda m: "re" in m.tags)
         assert len(selection) == 1
         assert selection[0].name == "2-re"
 
-        selection = matches.named("2-re", lambda m: "re" in m.tags, index=1000)
-        assert selection is None
+        single = matches.named("2-re", lambda m: "re" in m.tags, index=1000)
+        assert single is None
 
     def test_raw(self) -> None:
         input_string = "0123456789"
@@ -547,7 +549,7 @@ class TestMaches:
         input_string = "Test hole - with many separators + included"
         match = StringPattern("many").matches(input_string)
 
-        matches = Matches(match, input_string)  # type: ignore[arg-type]
+        matches = Matches(match, input_string)
         holes = matches.holes()
 
         assert len(holes) == 2

--- a/rebulk/test/test_processors.py
+++ b/rebulk/test/test_processors.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 from __future__ import annotations
 
-from typing import cast
-
-from ..match import Match, Matches
+from ..match import Matches
 from ..pattern import RePattern, StringPattern
 from ..processors import ConflictSolver
 from ..rules import execute_rule
@@ -13,7 +11,7 @@ def test_conflict_1() -> None:
     input_string = "abcdefghijklmnopqrstuvwxyz"
 
     pattern = StringPattern("ijklmn", "kl", "abcdef", "ab", "ef", "yz")
-    matches = Matches(cast("list[Match]", pattern.matches(input_string)))
+    matches = Matches(pattern.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
 
@@ -26,7 +24,7 @@ def test_conflict_2() -> None:
     input_string = "abcdefghijklmnopqrstuvwxyz"
 
     pattern = StringPattern("ijklmn", "jklmnopqrst")
-    matches = Matches(cast("list[Match]", pattern.matches(input_string)))
+    matches = Matches(pattern.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
 
@@ -39,7 +37,7 @@ def test_conflict_3() -> None:
     input_string = "abcdefghijklmnopqrstuvwxyz"
 
     pattern = StringPattern("ijklmnopqrst", "jklmnopqrst")
-    matches = Matches(cast("list[Match]", pattern.matches(input_string)))
+    matches = Matches(pattern.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
 
@@ -52,7 +50,7 @@ def test_conflict_4() -> None:
     input_string = "123456789"
 
     pattern = StringPattern("123", "456789")
-    matches = Matches(cast("list[Match]", pattern.matches(input_string)))
+    matches = Matches(pattern.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
 
@@ -64,7 +62,7 @@ def test_conflict_5() -> None:
     input_string = "123456789"
 
     pattern = StringPattern("123456", "789")
-    matches = Matches(cast("list[Match]", pattern.matches(input_string)))
+    matches = Matches(pattern.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
 
@@ -78,8 +76,8 @@ def test_prefer_longer_parent() -> None:
     re1 = RePattern("([0-9]+)x([0-9]+)", name="prefer", children=True, formatter=int)
     re2 = RePattern("x([0-9]+)", name="skip", children=True)
 
-    matches = Matches(cast("list[Match]", re1.matches(input_string)))
-    matches.extend(cast("list[Match]", re2.matches(input_string)))
+    matches = Matches(re1.matches(input_string))
+    matches.extend(re2.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
     assert len(matches) == 2
@@ -96,8 +94,8 @@ def test_conflict_solver_1() -> None:
     )
     re2 = StringPattern("34567")
 
-    matches = Matches(cast("list[Match]", re1.matches(input_string)))
-    matches.extend(cast("list[Match]", re2.matches(input_string)))
+    matches = Matches(re1.matches(input_string))
+    matches.extend(re2.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
     assert len(matches) == 1
@@ -116,8 +114,8 @@ def test_conflict_solver_2() -> None:
         conflict_solver=lambda match, conflicting: conflicting,
     )
 
-    matches = Matches(cast("list[Match]", re1.matches(input_string)))
-    matches.extend(cast("list[Match]", re2.matches(input_string)))
+    matches = Matches(re1.matches(input_string))
+    matches.extend(re2.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
     assert len(matches) == 1
@@ -133,8 +131,8 @@ def test_conflict_solver_3() -> None:
     )
     re2 = StringPattern("34567")
 
-    matches = Matches(cast("list[Match]", re1.matches(input_string)))
-    matches.extend(cast("list[Match]", re2.matches(input_string)))
+    matches = Matches(re1.matches(input_string))
+    matches.extend(re2.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
     assert len(matches) == 1
@@ -150,8 +148,8 @@ def test_conflict_solver_4() -> None:
         conflict_solver=lambda match, conflicting: conflicting,
     )
 
-    matches = Matches(cast("list[Match]", re1.matches(input_string)))
-    matches.extend(cast("list[Match]", re2.matches(input_string)))
+    matches = Matches(re1.matches(input_string))
+    matches.extend(re2.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
     assert len(matches) == 1
@@ -167,8 +165,8 @@ def test_conflict_solver_5() -> None:
     )
     re2 = StringPattern("34567")
 
-    matches = Matches(cast("list[Match]", re1.matches(input_string)))
-    matches.extend(cast("list[Match]", re2.matches(input_string)))
+    matches = Matches(re1.matches(input_string))
+    matches.extend(re2.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
     assert len(matches) == 1
@@ -184,8 +182,8 @@ def test_conflict_solver_6() -> None:
         conflict_solver=lambda match, conflicting: conflicting,
     )
 
-    matches = Matches(cast("list[Match]", re1.matches(input_string)))
-    matches.extend(cast("list[Match]", re2.matches(input_string)))
+    matches = Matches(re1.matches(input_string))
+    matches.extend(re2.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
     assert len(matches) == 1
@@ -198,8 +196,8 @@ def test_conflict_solver_7() -> None:
     re1 = StringPattern("102")
     re2 = StringPattern("02")
 
-    matches = Matches(cast("list[Match]", re2.matches(input_string)))
-    matches.extend(cast("list[Match]", re1.matches(input_string)))
+    matches = Matches(re2.matches(input_string))
+    matches.extend(re1.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
     assert len(matches) == 1
@@ -212,8 +210,8 @@ def test_unresolved() -> None:
     re1 = StringPattern("23456")
     re2 = StringPattern("34567")
 
-    matches = Matches(cast("list[Match]", re1.matches(input_string)))
-    matches.extend(cast("list[Match]", re2.matches(input_string)))
+    matches = Matches(re1.matches(input_string))
+    matches.extend(re2.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
     assert len(matches) == 2
@@ -224,8 +222,8 @@ def test_unresolved() -> None:
         conflict_solver=lambda match, conflicting: None,
     )
 
-    matches = Matches(cast("list[Match]", re1.matches(input_string)))
-    matches.extend(cast("list[Match]", re2.matches(input_string)))
+    matches = Matches(re1.matches(input_string))
+    matches.extend(re2.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
     assert len(matches) == 2
@@ -236,8 +234,8 @@ def test_unresolved() -> None:
     )
     re2 = StringPattern("2345678")
 
-    matches = Matches(cast("list[Match]", re1.matches(input_string)))
-    matches.extend(cast("list[Match]", re2.matches(input_string)))
+    matches = Matches(re1.matches(input_string))
+    matches.extend(re2.matches(input_string))
 
     execute_rule(ConflictSolver(), matches, None)
     assert len(matches) == 2

--- a/rebulk/test/test_rebulk.py
+++ b/rebulk/test/test_rebulk.py
@@ -323,6 +323,8 @@ class TestMarkers:
         class MarkerRule(Rule):
             def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
                 word_match = matches.named("word", 0)
+                if word_match is None:
+                    return None
                 marker = matches.markers.at_match(word_match, lambda marker: marker.name == "mark1", 0)
                 if not marker:
                     return word_match
@@ -354,6 +356,8 @@ class TestMarkers:
         class MarkerRule(Rule):
             def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
                 word_match = matches.named("word", 0)
+                if word_match is None:
+                    return None
                 marker = matches.markers.at_match(word_match, lambda marker: marker.name in ["mark1", "mark2"])
                 if len(marker) < 2:
                     return word_match
@@ -386,6 +390,8 @@ class TestMarkers:
         class MarkerRule(Rule):
             def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
                 word_match = matches.named("word", 0)
+                if word_match is None:
+                    return None
                 marker = matches.markers.at_index(word_match.start, lambda marker: marker.name == "mark1", 0)
                 if not marker:
                     return word_match

--- a/rebulk/test/test_rules.py
+++ b/rebulk/test/test_rules.py
@@ -164,7 +164,7 @@ class TestDefaultRules:
         rules.execute_all_rules(matches, {})
 
         assert len(matches.named("tags")) == 1
-        assert matches.named("tags", index=0).tags == ["other", "new-tag"]
+        assert matches.named("tags")[0].tags == ["other", "new-tag"]
 
         rules = Rules(RuleAppendTags1)
 
@@ -172,7 +172,7 @@ class TestDefaultRules:
         rules.execute_all_rules(matches, {})
 
         assert len(matches.named("tags")) == 1
-        assert matches.named("tags", index=0).tags == ["other", "new-tag"]
+        assert matches.named("tags")[0].tags == ["other", "new-tag"]
 
     def test_remove_tags(self) -> None:
         rules = Rules(RuleRemoveTags0)
@@ -181,7 +181,7 @@ class TestDefaultRules:
         rules.execute_all_rules(matches, {})
 
         assert len(matches.named("tags")) == 1
-        assert matches.named("tags", index=0).tags == ["other"]
+        assert matches.named("tags")[0].tags == ["other"]
 
         rules = Rules(RuleRemoveTags1)
 
@@ -189,7 +189,7 @@ class TestDefaultRules:
         rules.execute_all_rules(matches, {})
 
         assert len(matches.named("tags")) == 1
-        assert matches.named("tags", index=0).tags == ["other"]
+        assert matches.named("tags")[0].tags == ["other"]
 
 
 def test_rule_module() -> None:


### PR DESCRIPTION
## What

Adds `@overload` signatures to the `Matches`/`Match` query API so callers get precise types instead of `Any`.

The library ships `py.typed` and runs `mypy --strict`, but every query method returned `Any` because `filter_index()` returns *a list*, *a single `Match`*, or *`None`* depending on whether `index` is passed. Downstream users therefore got no usable type information.

## Behaviour of the new types

| call | before | after |
|------|--------|-------|
| `matches.named("x")` | `Any` | `list[Match]` |
| `matches.named("x", index=0)` | `Any` | `Match \| None` |
| `matches.named("x", 0)` (predicate-as-int shortcut) | `Any` | `Match \| None` |
| `matches.named("x", pred, 0)` | `Any` | `Match \| None` |
| `pattern.matches("x")` | `list \| tuple` | `list[Match]` |
| `pattern.matches("x", with_raw_matches=True)` | `list \| tuple` | `tuple[list[Match], list[Match]]` |

## Scope

- Overloaded (in `match.py`): `named`, `tagged`, `starting`, `ending`, `previous`, `next`, `conflicting`, `at_match`, `at_span`, `at_index`, `range`, `holes`, `chain_before`, `chain_after`, plus `Match.crop` / `Match.split`.
- `Pattern.matches` / `BasePattern.matches` gain `Literal[bool]` overloads; `Chain.matches` is aligned and its now-unnecessary `# type: ignore[override]` is removed.
- **No runtime behaviour change.** Redundant `cast(...)` calls that the new signatures make unnecessary are removed, and a handful of tests are narrowed where a method now correctly returns `Match | None`.

## Verification

- `mypy --strict`: clean (32 files)
- `pytest`: 166 passed, under **both** the stdlib `re` and the `regex` backend (`REBULK_REGEX_ENABLED=1`)
- `ruff check` / `ruff format` / full `pre-commit`: clean
- `reveal_type` probe confirms each public call resolves to the intended type

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)
