### PR TITLE
feat(typing): typed value retrieval — Key[T] and Matches.to(dataclass | TypedDict) (v5 POC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,22 @@ Movie(year=2008, title='Big Buck Bunny', tags=['HD', 'BluRay'])
 
 ```
 
+`Matches.to` also accepts a `TypedDict`, returning a typed dict (unmatched
+keys are simply omitted):
+
+```python
+>>> from typing import TypedDict
+>>> class MovieDict(TypedDict):
+...     year: int
+...     title: str
+...     tags: list[str]
+>>> Rebulk().regex(r'\d{4}', key=year).string('Big Buck Bunny', key=title) \
+...        .string('HD', key=tag).string('BluRay', key=tag) \
+...        .matches("Big Buck Bunny 2008 HD BluRay").to(MovieDict)
+{'year': 2008, 'title': 'Big Buck Bunny', 'tags': ['HD', 'BluRay']}
+
+```
+
 Markers
 =======
 

--- a/README.md
+++ b/README.md
@@ -509,6 +509,51 @@ It has the following additional methods and properties on it.
     A custom `Matches` sequences specialized for `markers` matches (see
     below)
 
+Typed retrieval
+===============
+
+By default `Match.value` is dynamically typed (`Any`). For type-safe access,
+declare a `Key` that binds a match name to its value type, and pass it to a
+builder method with `key=`. The value type is used as the formatter, and
+reading the value back through `Matches` is fully typed: `matches[key]`
+returns `T | None`, and `matches.all(key)` returns `list[T]`.
+
+```python
+>>> from rebulk import Rebulk, Key
+>>> year = Key("year", int)
+>>> title = Key("title", str)
+>>> matches = Rebulk().regex(r'\d{4}', key=year).string('Big Buck Bunny', key=title) \
+...                   .matches("Big Buck Bunny 2008")
+>>> matches[year]
+2008
+>>> matches.all(year)
+[2008]
+>>> matches[title]
+'Big Buck Bunny'
+
+```
+
+You can also project the matches onto a typed dataclass with `to`. Each field
+is filled from matches sharing its name: a `list[...]` field collects all
+values, any other field takes the first, and unmatched fields fall back to
+their default.
+
+```python
+>>> from dataclasses import dataclass, field
+>>> @dataclass
+... class Movie:
+...     year: int
+...     title: str
+...     tags: list[str] = field(default_factory=list)
+>>> tag = Key("tags", str)
+>>> matches = Rebulk().regex(r'\d{4}', key=year).string('Big Buck Bunny', key=title) \
+...                   .string('HD', key=tag).string('BluRay', key=tag) \
+...                   .matches("Big Buck Bunny 2008 HD BluRay")
+>>> matches.to(Movie)
+Movie(year=2008, title='Big Buck Bunny', tags=['HD', 'BluRay'])
+
+```
+
 Markers
 =======
 

--- a/README.md
+++ b/README.md
@@ -571,7 +571,8 @@ keys are simply omitted):
 ```
 
 `to` also accepts a primitive type (returns the first value) or a `list[...]`
-type (returns the values of all matches):
+of a scalar type (returns the values of all matches). A `list` of a dataclass
+or `TypedDict` is rejected, as a flat match sequence has no record grouping.
 
 ```python
 >>> Rebulk().regex(r'\d{4}', key=year).matches("born 1984").to(int)

--- a/README.md
+++ b/README.md
@@ -570,6 +570,18 @@ keys are simply omitted):
 
 ```
 
+`to` also accepts a primitive type (returns the first value) or a `list[...]`
+type (returns the values of all matches):
+
+```python
+>>> Rebulk().regex(r'\d{4}', key=year).matches("born 1984").to(int)
+1984
+>>> digit = Key("digit", int)
+>>> Rebulk().regex(r'\d', key=digit).matches("1 2 3").to(list[int])
+[1, 2, 3]
+
+```
+
 Markers
 =======
 

--- a/rebulk/__init__.py
+++ b/rebulk/__init__.py
@@ -3,6 +3,7 @@
 Define simple search patterns in bulk to perform advanced matching on any string.
 """
 
+from .key import Key
 from .processors import POST_PROCESS, PRE_PROCESS, ConflictSolver, PrivateRemover
 from .rebulk import Rebulk
 from .remodule import REGEX_ENABLED
@@ -16,6 +17,7 @@ __all__ = [
     "AppendTags",
     "ConflictSolver",
     "CustomRule",
+    "Key",
     "PrivateRemover",
     "Rebulk",
     "RemoveMatch",

--- a/rebulk/builder.py
+++ b/rebulk/builder.py
@@ -20,8 +20,20 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from .chain import Chain
+    from .key import Key
 
 log = getLogger(__name__).log
+
+
+def _apply_key(key: Key[Any] | None, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """
+    Inject a typed :class:`~rebulk.key.Key`'s name and value type (used as
+    formatter) into pattern kwargs, without overriding explicit values.
+    """
+    if key is not None:
+        kwargs.setdefault("name", key.name)
+        kwargs.setdefault("formatter", key.value_type)
+    return kwargs
 
 
 @contextmanager
@@ -202,38 +214,41 @@ class Builder(metaclass=ABCMeta):
         :return:
         """
 
-    def regex(self, *pattern: Any, **kwargs: Any) -> Self:
+    def regex(self, *pattern: Any, key: Key[Any] | None = None, **kwargs: Any) -> Self:
         """
         Add re pattern
 
         :param pattern:
         :type pattern:
+        :param key: optional typed key wiring up the match name and value type.
         :return: self
         :rtype: Rebulk
         """
-        return self.pattern(self.build_re(*pattern, **kwargs))
+        return self.pattern(self.build_re(*pattern, **_apply_key(key, kwargs)))
 
-    def string(self, *pattern: Any, **kwargs: Any) -> Self:
+    def string(self, *pattern: Any, key: Key[Any] | None = None, **kwargs: Any) -> Self:
         """
         Add string pattern
 
         :param pattern:
         :type pattern:
+        :param key: optional typed key wiring up the match name and value type.
         :return: self
         :rtype: Rebulk
         """
-        return self.pattern(self.build_string(*pattern, **kwargs))
+        return self.pattern(self.build_string(*pattern, **_apply_key(key, kwargs)))
 
-    def functional(self, *pattern: Any, **kwargs: Any) -> Self:
+    def functional(self, *pattern: Any, key: Key[Any] | None = None, **kwargs: Any) -> Self:
         """
         Add functional pattern
 
         :param pattern:
         :type pattern:
+        :param key: optional typed key wiring up the match name and value type.
         :return: self
         :rtype: Rebulk
         """
-        functional = self.build_functional(*pattern, **kwargs)
+        functional = self.build_functional(*pattern, **_apply_key(key, kwargs))
         return self.pattern(functional)
 
     def chain(self, **kwargs: Any) -> Chain:

--- a/rebulk/key.py
+++ b/rebulk/key.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""
+Typed keys binding a match name to its value type for type-safe retrieval.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class Key(Generic[T]):
+    r"""
+    A typed handle for a named match.
+
+    ``name`` is the match name to declare and look up; ``value_type`` is the type
+    of the match value and the ``(str) -> T`` converter applied to produce it
+    (e.g. ``int``, ``str``, ``float``). Passing a key to a builder method
+    (``key=...``) wires up both the match ``name`` and ``formatter``, so that
+    ``matches[key]`` and ``matches.all(key)`` return precise types instead of
+    ``Any``.
+
+    >>> from rebulk import Rebulk, Key
+    >>> year = Key("year", int)
+    >>> Rebulk().regex(r"\d{4}", key=year).matches("born in 1984")[year]
+    1984
+    """
+
+    name: str
+    value_type: type[T]

--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -9,14 +9,17 @@ import copy
 import itertools
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable, Iterable, KeysView, MutableSequence
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 from .debug import defined_at
+from .key import Key
 from .loose import ensure_list, filter_index
 from .utils import is_iterable
 
 if TYPE_CHECKING:
     from .debug import Frame
+
+T = TypeVar("T")
 
 
 class MatchesDict(OrderedDict):  # type: ignore[type-arg]
@@ -731,11 +734,23 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
     @overload
     def __getitem__(self, index: slice) -> Matches: ...
 
-    def __getitem__(self, index: int | slice) -> Match | Matches:
+    @overload
+    def __getitem__(self, index: Key[T]) -> T | None: ...
+
+    def __getitem__(self, index: int | slice | Key[Any]) -> Any:
+        if isinstance(index, Key):
+            named = self._name_dict[index.name]
+            return named[0].value if named else None
         ret = self._delegate[index]
         if isinstance(ret, list):
             return Matches(ret)
         return ret
+
+    def all(self, key: Key[T]) -> list[T]:
+        """
+        Retrieve all values for the given typed key, in match order.
+        """
+        return [match.value for match in self._name_dict[key.name]]
 
     @overload
     def __setitem__(self, index: int, match: Match) -> None: ...

--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -6,10 +6,11 @@ Classes and functions related to matches
 from __future__ import annotations
 
 import copy
+import dataclasses
 import itertools
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable, Iterable, KeysView, MutableSequence
-from typing import TYPE_CHECKING, Any, TypeVar, overload
+from typing import TYPE_CHECKING, Any, TypeVar, cast, get_origin, get_type_hints, overload
 
 from .debug import defined_at
 from .key import Key
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
     from .debug import Frame
 
 T = TypeVar("T")
+M = TypeVar("M")
 
 
 class MatchesDict(OrderedDict):  # type: ignore[type-arg]
@@ -751,6 +753,31 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
         Retrieve all values for the given typed key, in match order.
         """
         return [match.value for match in self._name_dict[key.name]]
+
+    def to(self, model: type[M]) -> M:
+        """
+        Build a typed dataclass instance from named matches.
+
+        Each dataclass field is populated from matches sharing its name: a
+        ``list[...]`` field collects all values (in match order), any other
+        field takes the first value. Fields with no matching value fall back to
+        their default (or raise, if the field is required). The result is typed
+        end to end via ``def to(self, model: type[M]) -> M``.
+
+        Values are used as produced by each pattern's formatter (see ``key=`` /
+        ``formatter=``); ``to`` does not coerce them.
+        """
+        if not dataclasses.is_dataclass(model):
+            raise TypeError(f"{model!r} is not a dataclass")
+        hints = get_type_hints(model)
+        kwargs: dict[str, Any] = {}
+        for data_field in dataclasses.fields(model):
+            values = [match.value for match in self._name_dict[data_field.name]]
+            if get_origin(hints.get(data_field.name)) is list:
+                kwargs[data_field.name] = values
+            elif values:
+                kwargs[data_field.name] = values[0]
+        return cast("M", model(**kwargs))
 
     @overload
     def __setitem__(self, index: int, match: Match) -> None: ...

--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -10,7 +10,7 @@ import dataclasses
 import itertools
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable, Iterable, KeysView, MutableSequence
-from typing import TYPE_CHECKING, Any, TypeVar, cast, get_origin, get_type_hints, is_typeddict, overload
+from typing import TYPE_CHECKING, Any, TypeVar, cast, get_args, get_origin, get_type_hints, is_typeddict, overload
 
 from .debug import defined_at
 from .key import Key
@@ -765,7 +765,10 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
           order), any other field takes the first value. A field with no value
           is left to its default (dataclass, or raises if required) or omitted
           (``TypedDict``).
-        * a ``list[...]`` type — returns the values of all matches.
+        * a ``list[...]`` type of a *scalar* item — returns the values of all
+          matches. ``list`` of a ``dataclass`` / ``TypedDict`` is rejected:
+          matches are a flat sequence with no record grouping to build several
+          structured items from.
         * any other type (e.g. ``int``, ``str``, ``float``) — returns the value
           of the first match, and raises ``LookupError`` if there is none.
 
@@ -774,6 +777,13 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
         ``formatter=``); ``to`` does not coerce them.
         """
         if get_origin(model) is list:
+            (item_type,) = get_args(model) or (object,)
+            if dataclasses.is_dataclass(item_type) or is_typeddict(item_type):
+                name = getattr(item_type, "__name__", item_type)
+                raise TypeError(
+                    f"list[{name}] is not supported: matches have no record grouping to build "
+                    "several structured items; use list of a scalar type, or a single dataclass/TypedDict"
+                )
             return cast("M", [match.value for match in self])
         if dataclasses.is_dataclass(model):
             hints = get_type_hints(model)

--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -10,7 +10,7 @@ import dataclasses
 import itertools
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable, Iterable, KeysView, MutableSequence
-from typing import TYPE_CHECKING, Any, TypeVar, get_origin, get_type_hints, is_typeddict, overload
+from typing import TYPE_CHECKING, Any, TypeVar, cast, get_origin, get_type_hints, is_typeddict, overload
 
 from .debug import defined_at
 from .key import Key
@@ -756,25 +756,37 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
 
     def to(self, model: type[M]) -> M:
         """
-        Build a typed ``dataclass`` or ``TypedDict`` instance from named matches.
+        Project named matches onto a typed model.
 
-        Each field is populated from matches sharing its name: a ``list[...]``
-        field collects all values (in match order), any other field takes the
-        first value. A field with no matching value is left to its default
-        (dataclass) or simply omitted (``TypedDict``); a required dataclass
-        field with no value and no default raises. The result is typed end to
-        end via ``def to(self, model: type[M]) -> M``.
+        ``model`` may be:
 
+        * a ``dataclass`` or ``TypedDict`` — each field is filled from matches
+          sharing its name: a ``list[...]`` field collects all values (in match
+          order), any other field takes the first value. A field with no value
+          is left to its default (dataclass, or raises if required) or omitted
+          (``TypedDict``).
+        * a ``list[...]`` type — returns the values of all matches.
+        * any other type (e.g. ``int``, ``str``, ``float``) — returns the value
+          of the first match, and raises ``LookupError`` if there is none.
+
+        The result is typed end to end via ``def to(self, model: type[M]) -> M``.
         Values are used as produced by each pattern's formatter (see ``key=`` /
         ``formatter=``); ``to`` does not coerce them.
         """
-        hints = get_type_hints(model)
+        if get_origin(model) is list:
+            return cast("M", [match.value for match in self])
         if dataclasses.is_dataclass(model):
+            hints = get_type_hints(model)
             field_names: Iterable[str] = [data_field.name for data_field in dataclasses.fields(model)]
         elif is_typeddict(model):
+            hints = get_type_hints(model)
             field_names = hints
+        elif isinstance(model, type):
+            if not self._delegate:
+                raise LookupError(f"no match available to build a {model.__name__}")
+            return cast("M", self[0].value)
         else:
-            raise TypeError(f"{model!r} is not a dataclass or TypedDict")
+            raise TypeError(f"{model!r} is not a dataclass, TypedDict, primitive or list type")
         kwargs: dict[str, Any] = {}
         for name in field_names:
             values = [match.value for match in self._name_dict[name]]

--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -10,7 +10,7 @@ import dataclasses
 import itertools
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable, Iterable, KeysView, MutableSequence
-from typing import TYPE_CHECKING, Any, TypeVar, cast, get_origin, get_type_hints, overload
+from typing import TYPE_CHECKING, Any, TypeVar, get_origin, get_type_hints, is_typeddict, overload
 
 from .debug import defined_at
 from .key import Key
@@ -756,28 +756,33 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
 
     def to(self, model: type[M]) -> M:
         """
-        Build a typed dataclass instance from named matches.
+        Build a typed ``dataclass`` or ``TypedDict`` instance from named matches.
 
-        Each dataclass field is populated from matches sharing its name: a
-        ``list[...]`` field collects all values (in match order), any other
-        field takes the first value. Fields with no matching value fall back to
-        their default (or raise, if the field is required). The result is typed
-        end to end via ``def to(self, model: type[M]) -> M``.
+        Each field is populated from matches sharing its name: a ``list[...]``
+        field collects all values (in match order), any other field takes the
+        first value. A field with no matching value is left to its default
+        (dataclass) or simply omitted (``TypedDict``); a required dataclass
+        field with no value and no default raises. The result is typed end to
+        end via ``def to(self, model: type[M]) -> M``.
 
         Values are used as produced by each pattern's formatter (see ``key=`` /
         ``formatter=``); ``to`` does not coerce them.
         """
-        if not dataclasses.is_dataclass(model):
-            raise TypeError(f"{model!r} is not a dataclass")
         hints = get_type_hints(model)
+        if dataclasses.is_dataclass(model):
+            field_names: Iterable[str] = [data_field.name for data_field in dataclasses.fields(model)]
+        elif is_typeddict(model):
+            field_names = hints
+        else:
+            raise TypeError(f"{model!r} is not a dataclass or TypedDict")
         kwargs: dict[str, Any] = {}
-        for data_field in dataclasses.fields(model):
-            values = [match.value for match in self._name_dict[data_field.name]]
-            if get_origin(hints.get(data_field.name)) is list:
-                kwargs[data_field.name] = values
+        for name in field_names:
+            values = [match.value for match in self._name_dict[name]]
+            if get_origin(hints.get(name)) is list:
+                kwargs[name] = values
             elif values:
-                kwargs[data_field.name] = values[0]
-        return cast("M", model(**kwargs))
+                kwargs[name] = values[0]
+        return model(**kwargs)
 
     @overload
     def __setitem__(self, index: int, match: Match) -> None: ...

--- a/rebulk/test/test_key.py
+++ b/rebulk/test/test_key.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""
+Tests for typed Key retrieval (POC for type-safe value access).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..key import Key
+from ..rebulk import Rebulk
+
+if TYPE_CHECKING:
+    from typing_extensions import assert_type
+
+    from ..match import Match
+
+
+def test_key_scalar_retrieval() -> None:
+    year = Key("year", int)
+    title = Key("title", str)
+
+    bulk = Rebulk().regex(r"\d{4}", key=year).string("Big Buck Bunny", key=title)
+    matches = bulk.matches("Big Buck Bunny 2008")
+
+    assert matches[year] == 2008
+    assert matches.all(year) == [2008]
+    assert matches[title] == "Big Buck Bunny"
+
+
+def test_key_missing_returns_none() -> None:
+    year = Key("year", int)
+    matches = Rebulk().regex(r"\d{4}", key=year).matches("no digits here")
+
+    assert matches[year] is None
+    assert matches.all(year) == []
+
+
+def test_key_multiple_values() -> None:
+    digit = Key("digit", int)
+    matches = Rebulk().regex(r"\d", key=digit).matches("1 2 3")
+
+    assert matches.all(digit) == [1, 2, 3]
+    assert matches[digit] == 1
+
+
+if TYPE_CHECKING:
+
+    def _reveal_types() -> None:
+        # Type-checked only (never executed): the typed key drives precise types.
+        year = Key("year", int)
+        title = Key("title", str)
+        matches = Rebulk().regex(r"\d{4}", key=year).string("x", key=title).matches("2008 x")
+
+        assert_type(matches[year], "int | None")
+        assert_type(matches.all(year), list[int])
+        assert_type(matches[title], "str | None")
+        # Existing integer / slice access stays intact.
+        assert_type(matches[0], Match)

--- a/rebulk/test/test_model.py
+++ b/rebulk/test/test_model.py
@@ -6,7 +6,7 @@ Tests for typed result models via Matches.to(dataclass) (v5 POC).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 import pytest
 
@@ -23,6 +23,12 @@ class Movie:
     title: str
     tags: list[str] = field(default_factory=list)
     resolution: str | None = None
+
+
+class MovieDict(TypedDict):
+    year: int
+    title: str
+    tags: list[str]
 
 
 def test_to_model() -> None:
@@ -52,9 +58,33 @@ def test_to_model_defaults_when_unmatched() -> None:
     assert movie.resolution is None  # optional scalar -> default
 
 
-def test_to_requires_dataclass() -> None:
+def test_to_typeddict() -> None:
+    year = Key("year", int)
+    title = Key("title", str)
+    tag = Key("tags", str)
+
+    bulk = (
+        Rebulk()
+        .regex(r"\d{4}", key=year)
+        .string("Big Buck Bunny", key=title)
+        .string("HD", key=tag)
+        .string("BluRay", key=tag)
+    )
+    movie = bulk.matches("Big Buck Bunny 2008 HD BluRay").to(MovieDict)
+
+    assert movie == {"year": 2008, "title": "Big Buck Bunny", "tags": ["HD", "BluRay"]}
+
+
+def test_to_typeddict_omits_unmatched() -> None:
+    year = Key("year", int)
+    movie = Rebulk().regex(r"\d{4}", key=year).matches("1999").to(MovieDict)
+
+    assert movie == {"year": 1999, "tags": []}  # unmatched scalar key omitted, list key kept
+
+
+def test_to_requires_dataclass_or_typeddict() -> None:
     matches = Rebulk().string("x").matches("x")
-    with pytest.raises(TypeError, match="not a dataclass"):
+    with pytest.raises(TypeError, match="not a dataclass or TypedDict"):
         matches.to(int)
 
 
@@ -63,3 +93,5 @@ if TYPE_CHECKING:
     def _reveal_types() -> None:
         movie = Rebulk().matches("").to(Movie)
         assert_type(movie, Movie)
+        movie_dict = Rebulk().matches("").to(MovieDict)
+        assert_type(movie_dict, MovieDict)

--- a/rebulk/test/test_model.py
+++ b/rebulk/test/test_model.py
@@ -96,6 +96,14 @@ def test_to_list() -> None:
     assert values == [1, 2, 3]
 
 
+def test_to_list_of_structured_rejected() -> None:
+    matches = Rebulk().regex(r"\d{4}", key=Key("year", int)).matches("1984 2008")
+    with pytest.raises(TypeError, match="no record grouping"):
+        matches.to(list[Movie])
+    with pytest.raises(TypeError, match="no record grouping"):
+        matches.to(list[MovieDict])
+
+
 def test_to_primitive_empty_raises() -> None:
     year = Key("year", int)
     matches = Rebulk().regex(r"\d{4}", key=year).matches("no digits")

--- a/rebulk/test/test_model.py
+++ b/rebulk/test/test_model.py
@@ -82,10 +82,32 @@ def test_to_typeddict_omits_unmatched() -> None:
     assert movie == {"year": 1999, "tags": []}  # unmatched scalar key omitted, list key kept
 
 
-def test_to_requires_dataclass_or_typeddict() -> None:
-    matches = Rebulk().string("x").matches("x")
-    with pytest.raises(TypeError, match="not a dataclass or TypedDict"):
+def test_to_primitive() -> None:
+    year = Key("year", int)
+    value = Rebulk().regex(r"\d{4}", key=year).matches("born 1984").to(int)
+
+    assert value == 1984
+
+
+def test_to_list() -> None:
+    digit = Key("digit", int)
+    values = Rebulk().regex(r"\d", key=digit).matches("1 2 3").to(list[int])
+
+    assert values == [1, 2, 3]
+
+
+def test_to_primitive_empty_raises() -> None:
+    year = Key("year", int)
+    matches = Rebulk().regex(r"\d{4}", key=year).matches("no digits")
+
+    with pytest.raises(LookupError):
         matches.to(int)
+
+
+def test_to_rejects_non_type() -> None:
+    matches = Rebulk().string("x").matches("x")
+    with pytest.raises(TypeError, match="not a dataclass"):
+        matches.to(42)  # type: ignore[arg-type]
 
 
 if TYPE_CHECKING:
@@ -95,3 +117,5 @@ if TYPE_CHECKING:
         assert_type(movie, Movie)
         movie_dict = Rebulk().matches("").to(MovieDict)
         assert_type(movie_dict, MovieDict)
+        assert_type(Rebulk().matches("").to(int), int)
+        assert_type(Rebulk().matches("").to(list[int]), list[int])

--- a/rebulk/test/test_model.py
+++ b/rebulk/test/test_model.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+"""
+Tests for typed result models via Matches.to(dataclass) (v5 POC).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ..key import Key
+from ..rebulk import Rebulk
+
+if TYPE_CHECKING:
+    from typing_extensions import assert_type
+
+
+@dataclass
+class Movie:
+    year: int
+    title: str
+    tags: list[str] = field(default_factory=list)
+    resolution: str | None = None
+
+
+def test_to_model() -> None:
+    year = Key("year", int)
+    title = Key("title", str)
+    tag = Key("tags", str)
+
+    bulk = (
+        Rebulk()
+        .regex(r"\d{4}", key=year)
+        .string("Big Buck Bunny", key=title)
+        .string("HD", key=tag)
+        .string("BluRay", key=tag)
+    )
+    movie = bulk.matches("Big Buck Bunny 2008 HD BluRay").to(Movie)
+
+    assert movie == Movie(year=2008, title="Big Buck Bunny", tags=["HD", "BluRay"], resolution=None)
+
+
+def test_to_model_defaults_when_unmatched() -> None:
+    year = Key("year", int)
+    title = Key("title", str)
+
+    movie = Rebulk().regex(r"\d{4}", key=year).string("Title", key=title).matches("Title 1999").to(Movie)
+
+    assert movie.tags == []  # list field -> empty
+    assert movie.resolution is None  # optional scalar -> default
+
+
+def test_to_requires_dataclass() -> None:
+    matches = Rebulk().string("x").matches("x")
+    with pytest.raises(TypeError, match="not a dataclass"):
+        matches.to(int)
+
+
+if TYPE_CHECKING:
+
+    def _reveal_types() -> None:
+        movie = Rebulk().matches("").to(Movie)
+        assert_type(movie, Movie)


### PR DESCRIPTION
## POC for #43 — type-safe value retrieval

Two layered, **purely additive** building blocks that type the boundary where users currently get `Any`. The dynamic engine and the string-based API are untouched; `match.value` stays `Any` by default.

### 1. Typed keys `Key[T]`

A typed handle binding a match **name** to its **value type**. Declaration stays fluent; retrieval is typed.

```python
from rebulk import Rebulk, Key

YEAR  = Key("year", int)
TITLE = Key("title", str)

matches = Rebulk().regex(r"\d{4}", key=YEAR).string("Big Buck Bunny", key=TITLE).matches("Big Buck Bunny 2008")

matches[YEAR]        # int | None     (was: Any)
matches.all(YEAR)    # list[int]
matches[TITLE]       # str | None
matches[0]           # Match          (existing access unchanged)
```

The value type is **named at the read site** (via the key), so each access has a single concrete `T` — no existentials needed, which is the wall a "generic everywhere" approach hits with heterogeneous `Matches`.

### 2. Typed result model — `Matches.to(dataclass | TypedDict)`

Describe the desired shape with a **dataclass** or a **`TypedDict`**; rebulk fills it.

```python
@dataclass
class Movie:
    year: int
    title: str
    tags: list[str] = field(default_factory=list)
    resolution: str | None = None

movie = bulk.matches("Big Buck Bunny 2008 HD BluRay").to(Movie)
# Movie(year=2008, title="Big Buck Bunny", tags=["HD", "BluRay"], resolution=None)

class MovieDict(TypedDict):
    year: int
    title: str
    tags: list[str]

bulk.matches("Big Buck Bunny 2008 HD BluRay").to(MovieDict)
# {"year": 2008, "title": "Big Buck Bunny", "tags": ["HD", "BluRay"]}
```

`list[...]` fields collect all values (match order), scalar fields take the first. Unmatched fields fall back to their default (dataclass, or raise if required) or are omitted (`TypedDict`). Typed end to end via `def to(self, model: type[M]) -> M` — `type[M]` accepts both a dataclass and a `TypedDict` and infers `M`.

## Design

- `rebulk/key.py`: `@dataclass(frozen=True) class Key(Generic[T])` — `name` + `value_type: type[T]` (also the `(str) -> T` converter).
- `Builder.regex/string/functional`: new `key=` keyword injecting `name`/`formatter` (explicit values win); still return `self` → chaining preserved.
- `Matches.__getitem__`: `Key[T] -> T | None` overload; new `Matches.all(key) -> list[T]`; new `Matches.to(type[M]) -> M` (dataclass or `TypedDict`, detected via `is_typeddict`).
- `Key` exported from the package root; README "Typed retrieval" section added.

## Scope / non-goals

- POC for **scalar** value types. Values are used as produced by each pattern's formatter (via `key=` / `formatter=`); neither `Key` nor `to()` coerces them.
- Left for follow-up: a formatter-based key (beyond `type[T]`) for non-scalar values, nested models, and an optional generic `Rebulk[Ctx]` for typed `context`.

## Verification

- `mypy --strict`: clean (35 files), including `assert_type` checks (dataclass + `TypedDict`) and a `reveal_type` probe
- `pytest`: 175 passed under **both** the `re` and `regex` backends (README + module doctests included)
- `ruff` / full `pre-commit`: clean

Refs #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
