### PR TITLE
fix(typing): reject dataclass/TypedDict as Key value_type

### DIFF
--- a/rebulk/key.py
+++ b/rebulk/key.py
@@ -5,8 +5,8 @@ Typed keys binding a match name to its value type for type-safe retrieval.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Generic, TypeVar
+from dataclasses import dataclass, is_dataclass
+from typing import Generic, TypeVar, is_typeddict
 
 T = TypeVar("T")
 
@@ -23,6 +23,11 @@ class Key(Generic[T]):
     ``matches[key]`` and ``matches.all(key)`` return precise types instead of
     ``Any``.
 
+    ``value_type`` must be a scalar ``(str) -> T`` converter: it is applied to a
+    single matched substring. Structured types (``dataclass`` / ``TypedDict``)
+    cannot be built from one string and are rejected here; assemble them from
+    several named matches with :meth:`Matches.to` instead.
+
     >>> from rebulk import Rebulk, Key
     >>> year = Key("year", int)
     >>> Rebulk().regex(r"\d{4}", key=year).matches("born in 1984")[year]
@@ -31,3 +36,10 @@ class Key(Generic[T]):
 
     name: str
     value_type: type[T]
+
+    def __post_init__(self) -> None:
+        if is_dataclass(self.value_type) or is_typeddict(self.value_type):
+            raise TypeError(
+                f"Key value_type must be a scalar (str) -> T converter, not {self.value_type!r}; "
+                "build structured types from several matches with Matches.to(...) instead"
+            )

--- a/rebulk/test/test_key.py
+++ b/rebulk/test/test_key.py
@@ -5,7 +5,10 @@ Tests for typed Key retrieval (POC for type-safe value access).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypedDict
+
+import pytest
 
 from ..key import Key
 from ..rebulk import Rebulk
@@ -26,6 +29,22 @@ def test_key_scalar_retrieval() -> None:
     assert matches[year] == 2008
     assert matches.all(year) == [2008]
     assert matches[title] == "Big Buck Bunny"
+
+
+def test_key_rejects_structured_value_type() -> None:
+    @dataclass
+    class Movie:
+        year: int
+        title: str
+
+    class MovieDict(TypedDict):
+        year: int
+        title: str
+
+    with pytest.raises(TypeError, match=r"Matches\.to"):
+        Key("movie", Movie)
+    with pytest.raises(TypeError, match=r"Matches\.to"):
+        Key("movie", MovieDict)
 
 
 def test_key_missing_returns_none() -> None:


### PR DESCRIPTION
A `Key`'s `value_type` doubles as the `(str) -> T` formatter applied to a **single** matched substring. A `dataclass` / `TypedDict` cannot be built from one string:

- it worked only by accident for a single-field dataclass (`Movie("hello")` → `Movie(title="hello")`),
- and raised an opaque `TypeError` / `ValueError` at value-access time otherwise.

Meanwhile `Key("m", Movie)` type-checked fine (`Key[Movie]`), so it was a silent footgun.

This adds a guard in `Key.__post_init__` that rejects a dataclass/TypedDict `value_type` **at construction**, with a clear message pointing to `Matches.to(...)` — the right tool to assemble several named matches into a structured object. Mirrors the `to(list[dataclass])` rejection already in place.

```python
Key("movie", Movie)
# TypeError: Key value_type must be a scalar (str) -> T converter, not <class 'Movie'>;
#            build structured types from several matches with Matches.to(...) instead
```

## Verification
- `mypy --strict`: clean
- `pytest`: 180 passed under both the `re` and `regex` backends
- `ruff` / full `pre-commit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)