### PR TITLE
feat(typing): Matches.named accepts multiple names (any-of)

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,9 +434,18 @@ It has the following additional methods and properties on it.
 
     Retrieves a list of `Match` objects that have the given tag defined.
 
--   `named(name, predicate=None, index=None)`
+-   `named(*names, predicate=None, index=None)`
 
-    Retrieves a list of `Match` objects that have the given name.
+    Retrieves a list of `Match` objects that have any of the given names
+    (in the order of the names, then match order within each).
+
+    ```python
+    >>> matches = Rebulk().regex(r'\d{4}', name="year").string("Big Buck Bunny", name="title") \
+    ...                   .matches("Big Buck Bunny 2008")
+    >>> [m.name for m in matches.named("title", "year")]
+    ['title', 'year']
+
+    ```
 
 -   `range(start=0, end=None, predicate=None, index=None)`
 

--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -230,8 +230,10 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
         :return: set of matches
         :rtype: list[Match]
         """
-        predicate = kwargs.get("predicate")
-        index = kwargs.get("index")
+        predicate = kwargs.pop("predicate", None)
+        index = kwargs.pop("index", None)
+        if kwargs:
+            raise TypeError(f"named() got unexpected keyword arguments {list(kwargs)}")
         name_list: list[str] = []
         extras: list[Any] = []
         for arg in names:

--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -210,22 +210,44 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
     @overload
     def named(self, name: str, predicate: Callable[[Match], Any] | None, index: int) -> Match | None: ...
     @overload
-    def named(self, name: str, predicate: Callable[[Match], Any] | None = ..., *, index: int) -> Match | None: ...
+    def named(self, name: str, predicate: Callable[[Match], Any] | None) -> list[Match]: ...
     @overload
-    def named(self, name: str, predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
-    def named(self, name: str, predicate: Callable[[Match], Any] | int | None = None, index: int | None = None) -> Any:
+    def named(self, *names: str, predicate: Callable[[Match], Any] | None = ..., index: int) -> Match | None: ...
+    @overload
+    def named(self, *names: str, predicate: Callable[[Match], Any] | None = ...) -> list[Match]: ...
+    def named(self, *names: Any, **kwargs: Any) -> Any:
         """
-        Retrieves a set of Match objects that have the given name.
-        :param name:
-        :type name: str
+        Retrieves a set of Match objects that have any of the given names.
+
+        Several names can be passed to select matches named by any of them (a
+        match has a single name, so this is an "any-of" selection), in the order
+        of the given names then match order within each. ``predicate`` and
+        ``index`` keep their usual meaning.
+
+        :param names: one or more match names.
         :param predicate:
-        :type predicate:
         :param index:
-        :type index: int
         :return: set of matches
-        :rtype: set[Match]
+        :rtype: list[Match]
         """
-        return filter_index(_BaseMatches._base(self._name_dict[name]), predicate, index)
+        predicate = kwargs.get("predicate")
+        index = kwargs.get("index")
+        name_list: list[str] = []
+        extras: list[Any] = []
+        for arg in names:
+            if isinstance(arg, str) and not extras:
+                name_list.append(arg)
+            else:
+                # positional predicate / index following the names
+                extras.append(arg)
+        if extras and predicate is None:
+            predicate = extras[0]
+        if len(extras) > 1 and index is None:
+            index = extras[1]
+        collection: list[Match] = []
+        for name in dict.fromkeys(name_list):
+            collection.extend(self._name_dict[name])
+        return filter_index(collection, predicate, index)
 
     @overload
     def tagged(self, tag: str, predicate: int) -> Match | None: ...

--- a/rebulk/test/test_match.py
+++ b/rebulk/test/test_match.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from ..formatters import formatters
 from ..match import Match, Matches
 from ..pattern import RePattern, StringPattern
+
+if TYPE_CHECKING:
+    from typing_extensions import assert_type
 
 
 class TestMatchClass:
@@ -558,3 +563,55 @@ class TestMaches:
 
         assert len(holes) == 4
         assert [hole.value for hole in holes] == ["Test hole ", " with ", " separators ", " included"]
+
+
+class TestNamedMultiple:
+    @staticmethod
+    def _matches() -> Matches:
+        input_string = "a b c d"
+        return Matches(
+            [
+                Match(0, 1, name="title", input_string=input_string),
+                Match(2, 3, name="episode_title", input_string=input_string),
+                Match(4, 5, name="title", input_string=input_string),
+                Match(6, 7, name="year", input_string=input_string),
+            ]
+        )
+
+    def test_any_of_several_names(self) -> None:
+        matches = self._matches()
+        selection = matches.named("title", "episode_title")
+        assert [(m.name, m.start) for m in selection] == [("title", 0), ("title", 4), ("episode_title", 2)]
+
+    def test_single_name_unchanged(self) -> None:
+        matches = self._matches()
+        assert [m.start for m in matches.named("title")] == [0, 4]
+
+    def test_index_with_multiple_names(self) -> None:
+        matches = self._matches()
+        first = matches.named("episode_title", "year", index=0)
+        assert first is not None
+        assert first.name == "episode_title"
+
+    def test_predicate_with_multiple_names(self) -> None:
+        matches = self._matches()
+        selection = matches.named("title", "year", predicate=lambda m: m.start > 3)
+        assert [m.start for m in selection] == [4, 6]
+
+    def test_duplicate_names_deduplicated(self) -> None:
+        matches = self._matches()
+        assert [m.start for m in matches.named("title", "title")] == [0, 4]
+
+    def test_missing_names(self) -> None:
+        matches = self._matches()
+        assert matches.named("nope", "nada") == []
+
+
+if TYPE_CHECKING:
+
+    def _named_reveal_types(matches: Matches) -> None:
+        assert_type(matches.named("title", "episode_title"), "list[Match]")
+        assert_type(matches.named("title", "episode_title", index=0), "Match | None")
+        assert_type(matches.named("title", index=0), "Match | None")
+        assert_type(matches.named("title", 0), "Match | None")
+        assert_type(matches.named("title", lambda m: True), "list[Match]")

--- a/rebulk/test/test_match.py
+++ b/rebulk/test/test_match.py
@@ -606,6 +606,11 @@ class TestNamedMultiple:
         matches = self._matches()
         assert matches.named("nope", "nada") == []
 
+    def test_unexpected_keyword_rejected(self) -> None:
+        matches = self._matches()
+        with pytest.raises(TypeError, match="unexpected keyword"):
+            matches.named("title", indx=0)  # type: ignore[call-overload]
+
 
 if TYPE_CHECKING:
 


### PR DESCRIPTION
Implements #46.

`Matches.named(*names)` now selects matches having **any** of the given names — turning the guessit idiom

```python
for title_match in (*matches.named("title"), *matches.named("episode_title")):
```

into

```python
for title_match in matches.named("title", "episode_title"):
```

## Why this is unambiguous (any-of, not AND)

At the `Matches` level each match has a single `.name` (`_name_dict` is keyed by `match.name`), so a match can never carry two names — "AND" is impossible and `named(*names)` can only mean any-of. This also aligns `Matches.named` with `Match.named(*names)`, which is already variadic with OR semantics.

(`tagged` is intentionally left out: a match can hold several tags, so OR/AND are both meaningful there and need explicit `tagged_any` / `tagged_all` — tracked separately.)

## Non-breaking

A `predicate` is never a `str`, so leading positional `str` args are names while the existing shortcuts keep working:

| Call | Meaning |
|------|---------|
| `named("title")` | unchanged |
| `named("title", 0)` | name + index (int shortcut) |
| `named("title", lambda m: ...)` | name + predicate |
| `named("title", "episode_title")` | any of the two names (new) |
| `named("title", "episode_title", index=0)` | first match of either name |

The `@overload`s keep precise return types (`list[Match]`, or `Match | None` with `index`); ordering across names is name order then match order within each, duplicate names are deduplicated.

## Verification

- `mypy --strict`: clean, with `assert_type` checks for the new and existing call forms
- `pytest`: 186 passed under both the `re` and `regex` backends (incl. a README doctest)
- `ruff` / full `pre-commit`: clean

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)