### PR TITLE
fix(chain): sort matches by match_index before groupby

### DIFF
--- a/rebulk/chain.py
+++ b/rebulk/chain.py
@@ -216,7 +216,10 @@ class Chain(Pattern, Builder):
     @staticmethod
     def _group_by_match_index(matches: Iterable[Match]) -> dict[int, list[Match]]:
         grouped_matches_dict: dict[int, list[Match]] = {}
-        for match_index, match in itertools.groupby(matches, lambda m: m.match_index):
+        # groupby only groups consecutive equal keys, so sort by match_index first
+        # to avoid splitting (and overwriting) groups when matches are unordered.
+        sorted_matches = sorted(matches, key=lambda m: m.match_index)
+        for match_index, match in itertools.groupby(sorted_matches, lambda m: m.match_index):
             grouped_matches_dict[match_index] = list(match)
         return grouped_matches_dict
 

--- a/rebulk/test/test_chain.py
+++ b/rebulk/test/test_chain.py
@@ -8,11 +8,12 @@ from typing import TYPE_CHECKING, Any
 from rebulk.pattern import FunctionalPattern, RePattern, StringPattern
 
 from ..chain import Chain
+from ..match import Match
 from ..rebulk import Rebulk
 from ..validators import chars_surround
 
 if TYPE_CHECKING:
-    from ..match import Match, Matches
+    from ..match import Matches
 
 
 def test_chain_close() -> None:
@@ -489,3 +490,22 @@ def test_chain_breaker_defaults2() -> None:
     matches[0].value = 1
     matches[1].value = 2
     matches[2].value = 3
+
+
+def test_group_by_match_index_sorts_unordered_input() -> None:
+    # groupby only groups consecutive equal keys, so _group_by_match_index must
+    # sort by match_index first; otherwise unordered matches split (and overwrite)
+    # groups sharing an index.
+    matches: list[Match] = []
+    for start, match_index in ((0, 2), (5, 0), (10, 1), (15, 2)):
+        match = Match(start, start + 1, name="test")
+        match.match_index = match_index
+        matches.append(match)
+
+    grouped = Chain._group_by_match_index(matches)
+
+    assert sorted(grouped) == [0, 1, 2]
+    assert [m.start for m in grouped[0]] == [5]
+    assert [m.start for m in grouped[1]] == [10]
+    # both match_index=2 matches are kept, in their original relative order
+    assert [m.start for m in grouped[2]] == [0, 15]


### PR DESCRIPTION
Reworked, rebased and cleaned-up version of #31 (thanks @denini08 for the catch — credited as co-author).

## Problem

`itertools.groupby` only groups **consecutive** equal keys. In `Chain._group_by_match_index`, when matches arrive unordered, groups sharing a `match_index` get split and the `grouped_matches_dict[match_index] = list(match)` assignment **overwrites** the earlier group, silently dropping matches.

## Fix

Sort by `match_index` before grouping — a no-op when the input is already ordered, and consistent with the `sorted()`-before-`groupby()` convention already used in `rules.py`.

```python
sorted_matches = sorted(matches, key=lambda m: m.match_index)
for match_index, match in itertools.groupby(sorted_matches, lambda m: m.match_index):
    ...
```

## What changed vs #31
- Rebased on current `develop` (the original no longer applied — `chain.py`/`test_chain.py` had diverged).
- Wrapped the line (the inline `sorted()` exceeded the 120-char limit → ruff E501).
- Rewrote the test to pass the gates: typed (`-> None`), no trailing whitespace, runtime `Match` import. It **fails without the fix** (the two `match_index=2` matches collapse to one) and passes with it.

## Verification
- `mypy --strict`: clean
- `pytest`: 188 passed under both the `re` and `regex` backends
- `ruff` / full `pre-commit`: clean
- Confirmed the new test fails on the pre-fix code

Supersedes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)