### PR TITLE
perf(utils): set-based extend_safe with unhashable fallback

### DIFF
--- a/rebulk/test/test_utils.py
+++ b/rebulk/test/test_utils.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+from typing import Any
+
+from ..utils import extend_safe
+
+
+def test_extend_safe_hashable() -> None:
+    target = [1, 2]
+    extend_safe(target, [2, 3, 3, 4])
+    assert target == [1, 2, 3, 4]
+
+
+def test_extend_safe_unhashable() -> None:
+    # Unhashable elements (e.g. introspected list/dict property values) must
+    # still be deduplicated via linear membership instead of raising.
+    target: list[Any] = [["a"]]
+    extend_safe(target, [["a"], ["b"], ["b"]])
+    assert target == [["a"], ["b"]]
+
+
+def test_extend_safe_mixed_falls_back_without_duplicating() -> None:
+    # Hashable elements go through the fast set path; the first unhashable one
+    # switches to the linear fallback, and already-added elements are not
+    # appended twice.
+    target: list[Any] = [1]
+    extend_safe(target, [1, 2, ["x"], ["x"], 2])
+    assert target == [1, 2, ["x"]]

--- a/rebulk/utils.py
+++ b/rebulk/utils.py
@@ -102,15 +102,28 @@ def is_iterable(obj: Any) -> bool:
 
 def extend_safe(target: list[_T], source: Iterable[_T]) -> None:
     """
-    Extends source list to target list only if elements doesn't exists in target list.
+    Extends target with elements from source that are not already present.
+
+    Uses a set for O(1) membership checks when elements are hashable (the common
+    case: patterns and rules are deduplicated on every ``matches()`` call), and
+    falls back to linear membership when they are not (e.g. unhashable
+    introspected property values).
+
     :param target:
     :type target: list
     :param source:
     :type source: list
     """
-    for elt in source:
-        if elt not in target:
-            target.append(elt)
+    try:
+        seen = set(target)
+        for elt in source:
+            if elt not in seen:
+                target.append(elt)
+                seen.add(elt)
+    except TypeError:  # unhashable element: fall back to linear membership checks
+        for elt in source:
+            if elt not in target:
+                target.append(elt)
 
 
 class _Ref:


### PR DESCRIPTION
Reworked, correctness-hardened version of #30 (thanks @allrob23 for the idea — credited as co-author).

## Why it's worth it

`extend_safe` deduplicates patterns and rules in `effective_patterns` / `effective_rules`, which run on **every** `Rebulk.matches()` call. guessit nests ~20 child rebulks (~130 patterns, ~19 rules), so this is genuinely on the hot path — the original O(n*m) linear membership is a small but real per-parse cost.

## Why the original #30 couldn't be merged as-is

`extend_safe` is also called from the introspector with **arbitrary user values** (`value=`, `properties=`), which can be **unhashable** (list/dict). A plain `set(target)` raises `TypeError: unhashable type` there — a regression.

## This version

Fast set-based path when elements are hashable (the patterns/rules hot path), with a linear fallback when they're not:

```python
try:
    seen = set(target)
    for elt in source:
        if elt not in seen:
            target.append(elt)
            seen.add(elt)
except TypeError:  # unhashable element
    for elt in source:
        if elt not in target:
            target.append(elt)
```

The fallback also covers the mid-loop case (hashable elements first, then an unhashable one) without double-appending already-added elements.

## Tests (new `test_utils.py`)
- hashable dedup,
- unhashable values (regression that #30 would crash on),
- mixed hashable→unhashable fallback without duplication.

## Verification
- `mypy --strict`: clean
- `pytest`: 191 passed under both the `re` and `regex` backends
- `ruff` / full `pre-commit`: clean

Supersedes #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)