### PR TITLE
fix(match): make Match.__hash__ independent of the mutable value

### DIFF
--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -1164,7 +1164,11 @@ class Match:
         return self.end - self.start
 
     def __hash__(self) -> int:
-        return hash(Match) + hash(self.start) + hash(self.end) + hash(self.value)
+        # Hash on the span only (a subset of the __eq__ fields), never on the
+        # mutable value: a match kept in a set/dict must stay findable after its
+        # value is changed. Equal matches still share a hash; same-span matches
+        # with different values collide harmlessly and __eq__ tells them apart.
+        return hash((Match, self.start, self.end))
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Match):

--- a/rebulk/test/test_match.py
+++ b/rebulk/test/test_match.py
@@ -51,11 +51,23 @@ class TestMatchClass:
         other = object()
 
         assert hash(match1) != hash(match2)
-        assert hash(match1) != hash(match3)
+        # same span, different value: hashes collide (hash must not depend on the
+        # mutable value); equality still tells them apart below.
+        assert hash(match1) == hash(match3)
 
         assert match1 != other
         assert match1 != match2
         assert match1 != match3
+
+    def test_hash_is_stable_under_value_mutation(self) -> None:
+        match = Match(1, 3, value="es")
+        bucket = {match}
+
+        match.value = "changed"
+
+        # The hash must not change when the value is mutated, so the match stays
+        # findable in the set it was added to.
+        assert match in bucket
 
     def test_length(self) -> None:
         match1 = Match(0, 4, value="test")


### PR DESCRIPTION
Fixes #34.

## Problem

`Match.__hash__` mixed in `self.value`:

```python
return hash(Match) + hash(self.start) + hash(self.end) + hash(self.value)
```

`value` has a public setter (and is assigned during pattern processing), so a `Match` placed in a `set`/`dict` and then mutated changes its hash and becomes unfindable — a broken hash/eq contract.

## Fix

Hash on the **span only** — a subset of the `__eq__` fields (`span`, `value`, `name`, `parent`), so the invariant *equal ⟹ equal hash* still holds:

```python
return hash((Match, self.start, self.end))
```

Same-span matches with different values now collide harmlessly, and `__eq__` still tells them apart. `value` (the field with a public setter, mutated during processing) no longer affects the hash.

## Tests
- New regression test: a match mutated **while held in a `set`** stays findable (fails on the old hash, passes now — verified).
- Updated `test_inequality`: two same-span / different-value matches now share a hash (expected collision); equality still distinguishes them.

## Verification
- `mypy --strict`: clean
- `pytest`: 192 passed under both the `re` and `regex` backends
- `ruff` / full `pre-commit`: clean

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)