### PR TITLE
refactor: drop dead getargspec fallback and leftover commented code

### DIFF
--- a/rebulk/__version__.py
+++ b/rebulk/__version__.py
@@ -3,5 +3,4 @@
 Version module
 """
 
-# pragma: no cover
 __version__ = "4.2.1"

--- a/rebulk/loose.py
+++ b/rebulk/loose.py
@@ -5,16 +5,8 @@ Various utilities functions
 
 from __future__ import annotations
 
-from inspect import isclass
+from inspect import getfullargspec, isclass
 from typing import TYPE_CHECKING, Any, cast
-
-try:
-    from inspect import getfullargspec as getargspec
-
-    _FULLARGSPEC_SUPPORTED = True
-except ImportError:
-    _FULLARGSPEC_SUPPORTED = False
-    from inspect import getargspec  # type: ignore[assignment]  # removed in Python 3.11, dead on supported versions
 
 from .utils import is_iterable
 
@@ -66,7 +58,7 @@ def function_args(callable_: Any, *args: Any, **kwargs: Any) -> tuple[Any, Any]:
     :return: (args, kwargs) matching the function signature
     :rtype: tuple
     """
-    argspec = getargspec(callable_)
+    argspec = getfullargspec(callable_)
     return argspec_args(argspec, False, *args, **kwargs)
 
 
@@ -83,7 +75,7 @@ def constructor_args(class_: Any, *args: Any, **kwargs: Any) -> tuple[Any, Any]:
     :return: (args, kwargs) matching the function signature
     :rtype: tuple
     """
-    argspec = getargspec(_constructor(class_))
+    argspec = getfullargspec(_constructor(class_))
     return argspec_args(argspec, True, *args, **kwargs)
 
 
@@ -105,30 +97,6 @@ def argspec_args(argspec: FullArgSpec, constructor: bool, *args: Any, **kwargs: 
     call_kwarg = kwargs if argspec.varkw else {k: kwargs[k] for k in kwargs if k in argspec.args}
     call_args = args if argspec.varargs else args[: len(argspec.args) - (1 if constructor else 0)]
     return call_args, call_kwarg
-
-
-if not _FULLARGSPEC_SUPPORTED:
-
-    def argspec_args_legacy(argspec: Any, constructor: bool, *args: Any, **kwargs: Any) -> tuple[Any, Any]:
-        """
-        Return (args, kwargs) matching the argspec object
-
-        :param argspec: argspec to use
-        :type argspec: argspec
-        :param constructor: is it a constructor ?
-        :type constructor: bool
-        :param args:
-        :type args:
-        :param kwargs:
-        :type kwargs:
-        :return: (args, kwargs) matching the function signature
-        :rtype: tuple
-        """
-        call_kwarg = kwargs if argspec.keywords else {k: kwargs[k] for k in kwargs if k in argspec.args}
-        call_args = args if argspec.varargs else args[: len(argspec.args) - (1 if constructor else 0)]
-        return call_args, call_kwarg
-
-    argspec_args = argspec_args_legacy
 
 
 def ensure_list(param: Any) -> list[Any]:

--- a/rebulk/rebulk.py
+++ b/rebulk/rebulk.py
@@ -189,9 +189,6 @@ class Rebulk(Builder):
                     pattern_matches = pattern.matches(cast("str", matches.input_string), context)
                     if pattern_matches:
                         log(pattern.log_level, "Pattern has %s match(es). (%s)", len(pattern_matches), pattern)
-                    else:
-                        pass
-                        # log(pattern.log_level, "Pattern doesn't match. (%s)" % (pattern,))
                     for match in pattern_matches:
                         if match.marker:
                             log(pattern.log_level, "Marker found. (%s)", match)


### PR DESCRIPTION
Two small, behaviour-preserving cleanups.

### #37 — dead `getargspec` fallback (`loose.py`)
`getfullargspec` has existed since Python 3.3 and `getargspec` was *removed* in 3.11, so on the supported **3.10+** range the `try/except ImportError` branch and `argspec_args_legacy` were unreachable. Import `getfullargspec` directly and drop the flag + legacy function.

### #39 — leftover commented code
- `rebulk.py`: removed the empty `else: pass` with a commented-out `log(...)` call.
- `__version__.py`: dropped the stray module-level `# pragma: no cover` (the file is already omitted in `.coveragerc`).

## Verification
- `mypy --strict`: clean
- `pytest`: 192 passed under both the `re` and `regex` backends
- `ruff` / full `pre-commit`: clean

Closes #37
Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)