### PR TITLE
ci: enforce coverage floor and scope mypy ignore_missing_imports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,5 +6,8 @@ omit =
     rebulk/__version__.py
     rebulk/test/*
 [report]
+# Current coverage is ~96% on both backends; 95 is a floor that catches real
+# regressions without flaking on minor per-interpreter/per-backend differences.
+fail_under = 95
 exclude_lines =
     pragma: no cover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
         env:
           REBULK_REGEX_ENABLED: ${{ matrix.regex }}
 
+      - name: Coverage report
+        # Fails the job below the fail_under threshold set in .coveragerc.
+        run: uv run --no-sync coverage report
+
       - name: Build
         run: uv build
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,11 @@ select = [
 python_version = "3.10"
 files = ["rebulk"]
 strict = true
+
+[[tool.mypy.overrides]]
+# `regex` (the optional `native` extra) ships no type information; scope the
+# relaxation to it instead of silencing missing imports across the whole project.
+module = ["regex.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Two tooling hardening changes.

### #35 — coverage floor
- `.coveragerc`: `fail_under = 95` (current coverage is ~96% on both backends: 96.1% with `re`, 96.6% with `regex`).
- `ci.yml`: a `coverage report` step in the test matrix, so a regression below 95% fails CI instead of only being uploaded to Coveralls. 95 is a floor that catches real regressions without flaking on minor per-interpreter/per-backend differences.

### #36 — scope mypy `ignore_missing_imports`
Dropped the global `ignore_missing_imports = true` (which weakened strict mode across the whole project) and scoped it to the only dependency without type info — `regex` (the optional `native` extra) — via a per-module override. Genuine missing/typo'd imports elsewhere are now caught again.

## Verification
- `mypy --strict`: clean (with and without the regex backend)
- `coverage report`: exits 0 (≥95) on both backends
- `pytest`: 192 passed; `ruff` / full `pre-commit`: clean

Closes #35
Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)