### PR TITLE
refactor(pattern): DRY Pattern.__init__ and RePattern._match

### DIFF
--- a/rebulk/pattern.py
+++ b/rebulk/pattern.py
@@ -20,6 +20,11 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
 
 
+def _callable_or_none(value: Any) -> Callable[..., Any] | None:
+    """Return ``value`` if it is callable, else ``None``."""
+    return value if callable(value) else None
+
+
 class BasePattern(metaclass=ABCMeta):
     """
     Base class for Pattern like objects
@@ -144,21 +149,9 @@ class Pattern(BasePattern, metaclass=ABCMeta):
         self._log_level = log_level
         self._properties = properties
         self.defined_at = debug.defined_at()
-        self.post_processor: Callable[..., Any] | None
-        if not callable(post_processor):
-            self.post_processor = None
-        else:
-            self.post_processor = post_processor
-        self.pre_match_processor: Callable[..., Any] | None
-        if not callable(pre_match_processor):
-            self.pre_match_processor = None
-        else:
-            self.pre_match_processor = pre_match_processor
-        self.post_match_processor: Callable[..., Any] | None
-        if not callable(post_match_processor):
-            self.post_match_processor = None
-        else:
-            self.post_match_processor = post_match_processor
+        self.post_processor = _callable_or_none(post_processor)
+        self.pre_match_processor = _callable_or_none(pre_match_processor)
+        self.post_match_processor = _callable_or_none(post_match_processor)
 
     @property
     def log_level(self) -> int:
@@ -517,32 +510,22 @@ class RePattern(Pattern):
                 for i in range(1, pattern.groups + 1):
                     name = names.get(i, main_match.name)
                     if self.repeated_captures:
-                        for start, end in match_object.spans(i):
-                            child_match = Match(
-                                start,
-                                end,
-                                name=name,
-                                parent=main_match,
-                                pattern=self,
-                                input_string=input_string,
-                                **self._children_match_kwargs,
-                            )
-                            if child_match:
-                                main_match.children.append(child_match)
+                        spans = match_object.spans(i)
                     else:
-                        start, end = match_object.span(i)
-                        if start > -1 and end > -1:
-                            child_match = Match(
-                                start,
-                                end,
-                                name=name,
-                                parent=main_match,
-                                pattern=self,
-                                input_string=input_string,
-                                **self._children_match_kwargs,
-                            )
-                            if child_match:
-                                main_match.children.append(child_match)
+                        span = match_object.span(i)
+                        spans = [span] if span[0] > -1 and span[1] > -1 else []
+                    for child_start, child_end in spans:
+                        child_match = Match(
+                            child_start,
+                            child_end,
+                            name=name,
+                            parent=main_match,
+                            pattern=self,
+                            input_string=input_string,
+                            **self._children_match_kwargs,
+                        )
+                        if child_match:
+                            main_match.children.append(child_match)
 
             if main_match:
                 yield main_match


### PR DESCRIPTION
Two behaviour-preserving deduplications in `pattern.py` (closes #40).

### `Pattern.__init__`
The three identical *callable-or-None* blocks (4 lines each) for `post_processor` / `pre_match_processor` / `post_match_processor` now share a small `_callable_or_none()` helper:

```python
self.post_processor = _callable_or_none(post_processor)
self.pre_match_processor = _callable_or_none(pre_match_processor)
self.post_match_processor = _callable_or_none(post_match_processor)
```

### `RePattern._match`
The child-`Match` construction was duplicated across the `repeated_captures` branch (`match_object.spans(i)`) and the single-span branch (`match_object.span(i)`). Only the source of spans differs, so it now computes the spans per branch and builds/appends children in **one** loop.

## Verification
- Behaviour-preserving: both branches are exercised by the `re` backend (single span) and the `regex` backend (`repeated_captures`).
- `mypy --strict`: clean
- `pytest`: 192 passed under both backends
- `ruff` / full `pre-commit`: clean

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)