### PR TITLE
chore(toposort): purge Python 2 remnants from the vendored module

### DIFF
--- a/rebulk/toposort.py
+++ b/rebulk/toposort.py
@@ -1,18 +1,10 @@
 #!/usr/bin/env python
-# Copyright 2014 True Blade Systems, Inc.
+# Vendored from toposort 1.4 (https://bitbucket.org/ericvsmith/toposort),
+# Copyright 2014 True Blade Systems, Inc., licensed under the Apache License,
+# Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0).
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Original:
-#   - https://bitbucket.org/ericvsmith/toposort (1.4)
-# Modifications:
-#   - merged Pull request #2 for CyclicDependency error
-#   - import reduce as original name
-#   - support python 2.6 dict comprehension
+# Local changes: CyclicDependency error (upstream pull request #2), Python 3
+# only, fully type-annotated.
 
 from __future__ import annotations
 
@@ -27,7 +19,7 @@ _T = TypeVar("_T")
 
 class CyclicDependency(ValueError):
     def __init__(self, cyclic: dict[_T, set[_T]]) -> None:
-        s = "Cyclic dependencies exist among these items: {}".format(", ".join(repr(x) for x in cyclic.items()))
+        s = f"Cyclic dependencies exist among these items: {', '.join(repr(x) for x in cyclic.items())}"
         super().__init__(s)
         self.cyclic = cyclic
 
@@ -38,7 +30,7 @@ def toposort(data: dict[_T, set[_T]]) -> Iterator[set[_T]]:
     and whose values are a set of dependent items. Output is a list of
     sets in topological order. The first set consists of items with no
     dependences, each subsequent set consists of items that depend upon
-    items in the preceeding sets.
+    items in the preceding sets.
     :param data:
     :type data:
     :return:


### PR DESCRIPTION
Per the decision to **keep `toposort` vendored** (no new dependency), this just cleans the module:

- Trim the header to the required Apache attribution + a concise change note, dropping the obsolete `support python 2.6 dict comprehension` modification line.
- Convert the `CyclicDependency` message from `"...".format(...)` to an f-string (matches the codebase style).
- Fix a `preceeding` → `preceding` typo.

No behaviour change; the module stays fully type-annotated. `toposort_flatten` is kept (covered by `test_toposort.py`).

## Verification
- `mypy --strict`: clean
- `pytest`: 192 passed under both the `re` and `regex` backends
- `ruff` / full `pre-commit`: clean

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)