### PR TITLE
refactor(chain): type ChainPart fluent methods instead of Any

### DIFF
--- a/rebulk/chain.py
+++ b/rebulk/chain.py
@@ -324,7 +324,7 @@ class ChainPart(BasePattern):
         if max_match_index + 1 < self.repeater_start:
             raise _InvalidChainException
 
-    def chain(self) -> Any:
+    def chain(self) -> Chain:
         """
         Add patterns chain, using configuration from this chain
 
@@ -354,7 +354,7 @@ class ChainPart(BasePattern):
         """
         return self._hidden
 
-    def regex(self, *pattern: Any, **kwargs: Any) -> Any:
+    def regex(self, *pattern: Any, **kwargs: Any) -> ChainPart:
         """
         Add re pattern
 
@@ -365,9 +365,11 @@ class ChainPart(BasePattern):
         :return:
         :rtype:
         """
-        return self._chain.regex(*pattern, **kwargs)
+        # The builder's regex/string/functional are typed `-> Self` (Chain), but
+        # Chain.pattern() yields a ChainPart, which is what is actually returned.
+        return cast("ChainPart", self._chain.regex(*pattern, **kwargs))
 
-    def functional(self, *pattern: Any, **kwargs: Any) -> Any:
+    def functional(self, *pattern: Any, **kwargs: Any) -> ChainPart:
         """
         Add functional pattern
 
@@ -378,9 +380,9 @@ class ChainPart(BasePattern):
         :return:
         :rtype:
         """
-        return self._chain.functional(*pattern, **kwargs)
+        return cast("ChainPart", self._chain.functional(*pattern, **kwargs))
 
-    def string(self, *pattern: Any, **kwargs: Any) -> Any:
+    def string(self, *pattern: Any, **kwargs: Any) -> ChainPart:
         """
         Add string pattern
 
@@ -391,7 +393,7 @@ class ChainPart(BasePattern):
         :return:
         :rtype:
         """
-        return self._chain.string(*pattern, **kwargs)
+        return cast("ChainPart", self._chain.string(*pattern, **kwargs))
 
     def close(self) -> Any:
         """


### PR DESCRIPTION
The safe, contained part of the Chain cleanup (option A from the v5 analysis, #43).

`ChainPart.regex/string/functional` now return `ChainPart` and `ChainPart.chain()` returns `Chain`, replacing `-> Any`. The three delegating methods `cast(...)` the result, because the underlying `Builder.regex/string/functional` are typed `-> Self` while `Chain.pattern()` actually yields a `ChainPart` (the existing Liskov quirk).

**Typing-only, no runtime change.**

### Scope / honesty
This types `ChainPart`'s own surface. The *entry* call `rebulk.chain().regex(...)` is still typed `Chain` (because `Builder.regex -> Self`), so end-to-end typing of the fluent chain still requires the deeper Chain/Builder decoupling — deliberately **deferred to v5** (it doesn't cleanly remove the circular import or the Liskov `type: ignore`, and would be micro-breaking; see `docs/v5-design.md` §3.1 and the decisions in §6).

### Verification
- `mypy --strict`: clean (the casts are accepted, not redundant)
- `pytest`: 192 passed under both the `re` and `regex` backends
- `ruff` / full `pre-commit`: clean

Refs #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)