### PR TITLE
feat(typing): formatter-based Key for non-scalar values

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,3 +11,4 @@ omit =
 fail_under = 95
 exclude_lines =
     pragma: no cover
+    if TYPE_CHECKING:

--- a/README.md
+++ b/README.md
@@ -542,6 +542,17 @@ returns `T | None`, and `matches.all(key)` returns `list[T]`.
 
 ```
 
+For values that aren't built straight from a string, pass an explicit
+`formatter` (a `(str) -> T` converter); the key stays fully typed as `T`.
+
+```python
+>>> from datetime import date
+>>> released = Key("released", date, formatter=date.fromisoformat)
+>>> Rebulk().regex(r'\d{4}-\d{2}-\d{2}', key=released).matches("on 2008-01-02")[released]
+datetime.date(2008, 1, 2)
+
+```
+
 You can also project the matches onto a typed dataclass with `to`. Each field
 is filled from matches sharing its name: a `list[...]` field collects all
 values, any other field takes the first, and unmatched fields fall back to

--- a/rebulk/builder.py
+++ b/rebulk/builder.py
@@ -27,12 +27,13 @@ log = getLogger(__name__).log
 
 def _apply_key(key: Key[Any] | None, kwargs: dict[str, Any]) -> dict[str, Any]:
     """
-    Inject a typed :class:`~rebulk.key.Key`'s name and value type (used as
-    formatter) into pattern kwargs, without overriding explicit values.
+    Inject a typed :class:`~rebulk.key.Key`'s name and converter (its explicit
+    ``formatter`` or its ``value_type``) into pattern kwargs, without overriding
+    explicit values.
     """
     if key is not None:
         kwargs.setdefault("name", key.name)
-        kwargs.setdefault("formatter", key.value_type)
+        kwargs.setdefault("formatter", key.converter)
     return kwargs
 
 

--- a/rebulk/key.py
+++ b/rebulk/key.py
@@ -6,7 +6,10 @@ Typed keys binding a match name to its value type for type-safe retrieval.
 from __future__ import annotations
 
 from dataclasses import dataclass, is_dataclass
-from typing import Generic, TypeVar, is_typeddict
+from typing import TYPE_CHECKING, Generic, TypeVar, is_typeddict
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 T = TypeVar("T")
 
@@ -17,16 +20,20 @@ class Key(Generic[T]):
     A typed handle for a named match.
 
     ``name`` is the match name to declare and look up; ``value_type`` is the type
-    of the match value and the ``(str) -> T`` converter applied to produce it
-    (e.g. ``int``, ``str``, ``float``). Passing a key to a builder method
-    (``key=...``) wires up both the match ``name`` and ``formatter``, so that
-    ``matches[key]`` and ``matches.all(key)`` return precise types instead of
-    ``Any``.
+    of the match value (e.g. ``int``, ``str``, ``float``). ``formatter``, if
+    given, is the ``(str) -> T`` converter applied to the matched substring; when
+    omitted it defaults to ``value_type`` itself (so ``Key("year", int)`` casts
+    with ``int``). Use ``formatter`` for values not constructible straight from a
+    string, e.g. ``Key("released", date, formatter=date.fromisoformat)``.
 
-    ``value_type`` must be a scalar ``(str) -> T`` converter: it is applied to a
-    single matched substring. Structured types (``dataclass`` / ``TypedDict``)
-    cannot be built from one string and are rejected here; assemble them from
-    several named matches with :meth:`Matches.to` instead.
+    Passing a key to a builder method (``key=...``) wires up both the match
+    ``name`` and the formatter, so that ``matches[key]`` and ``matches.all(key)``
+    return precise types instead of ``Any``.
+
+    ``value_type`` must be a scalar type (it/the formatter is applied to a single
+    matched substring). Structured types (``dataclass`` / ``TypedDict``) cannot
+    be built from one string and are rejected here; assemble them from several
+    named matches with :meth:`Matches.to` instead.
 
     >>> from rebulk import Rebulk, Key
     >>> year = Key("year", int)
@@ -36,10 +43,16 @@ class Key(Generic[T]):
 
     name: str
     value_type: type[T]
+    formatter: Callable[[str], T] | None = None
 
     def __post_init__(self) -> None:
         if is_dataclass(self.value_type) or is_typeddict(self.value_type):
             raise TypeError(
-                f"Key value_type must be a scalar (str) -> T converter, not {self.value_type!r}; "
+                f"Key value_type must be a scalar type, not {self.value_type!r}; "
                 "build structured types from several matches with Matches.to(...) instead"
             )
+
+    @property
+    def converter(self) -> Callable[[str], T]:
+        """The ``(str) -> T`` converter: the explicit ``formatter`` or ``value_type``."""
+        return self.formatter if self.formatter is not None else self.value_type

--- a/rebulk/test/test_key.py
+++ b/rebulk/test/test_key.py
@@ -6,6 +6,7 @@ Tests for typed Key retrieval (POC for type-safe value access).
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
 from typing import TYPE_CHECKING, TypedDict
 
 import pytest
@@ -29,6 +30,20 @@ def test_key_scalar_retrieval() -> None:
     assert matches[year] == 2008
     assert matches.all(year) == [2008]
     assert matches[title] == "Big Buck Bunny"
+
+
+def test_key_converter_defaults_to_value_type() -> None:
+    assert Key("year", int).converter is int
+    fmt = date.fromisoformat
+    assert Key("released", date, formatter=fmt).converter is fmt
+
+
+def test_key_with_explicit_formatter() -> None:
+    released = Key("released", date, formatter=date.fromisoformat)
+    matches = Rebulk().regex(r"\d{4}-\d{2}-\d{2}", key=released).matches("on 2008-01-02 ...")
+
+    assert matches[released] == date(2008, 1, 2)
+    assert matches.all(released) == [date(2008, 1, 2)]
 
 
 def test_key_rejects_structured_value_type() -> None:
@@ -74,5 +89,8 @@ if TYPE_CHECKING:
         assert_type(matches[year], "int | None")
         assert_type(matches.all(year), list[int])
         assert_type(matches[title], "str | None")
+        # A formatter-based key keeps the precise value type.
+        released = Key("released", date, formatter=date.fromisoformat)
+        assert_type(matches[released], "date | None")
         # Existing integer / slice access stays intact.
         assert_type(matches[0], Match)


### PR DESCRIPTION
Implements #58 (v5 plan item 3.3 — additive, 4.x).

Adds an optional `Key.formatter` (a `(str) -> T` converter) defaulting to `value_type`, exposed via a `Key.converter` property and wired through the builder — so a key can carry a custom converter for values not constructible straight from a string, fully typed end to end:

```python
from datetime import date
released = Key("released", date, formatter=date.fromisoformat)
matches[released]   # -> date | None
```

- Additive: `Key("year", int)` is unchanged.
- `Builder._apply_key` uses `key.converter`.
- Tests: explicit-formatter retrieval, `converter` default, `assert_type`; README "Typed retrieval" doctest added.

## Acceptance criteria (#58)
- [x] `Key.formatter` field + `Key.converter` property
- [x] Builder wires the converter; `Key("year", int)` unchanged
- [x] `matches[released]` / `matches.all(released)` typed `date` / `list[date]` (assert_type)
- [x] README doctest for the formatter case
- [x] mypy --strict clean; tests green on both backends

## Verification
- `mypy --strict`: clean
- `pytest`: 194 passed under both the `re` and `regex` backends (incl. README doctest)
- `ruff` / full `pre-commit`: clean

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)