### PR TITLE
feat(typing): typable predictable shape for to_dict(enforce_list=True)

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,10 @@ It has the following additional methods and properties on it.
     `Match.value` as value.
 
     if `enforce_list` is `True`, all values will be wrapped to a list,
-    even if a single value is found.
+    even if a single value is found. This form has a predictable, typed
+    shape (`MatchesDict[list]`), unlike the default which is a scalar *or*
+    a list per name. For fully typed access, prefer the typed retrieval
+    API above (`Key` and `Matches.to(...)`).
 
     If `details` is True, `Match.value` objects are replaced with
     complete `Match` object.

--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -10,7 +10,18 @@ import dataclasses
 import itertools
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable, Iterable, KeysView, MutableSequence
-from typing import TYPE_CHECKING, Any, TypeVar, cast, get_args, get_origin, get_type_hints, is_typeddict, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+    is_typeddict,
+    overload,
+)
 
 from .debug import defined_at
 from .key import Key
@@ -22,11 +33,17 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 M = TypeVar("M")
+_V = TypeVar("_V")
 
 
-class MatchesDict(OrderedDict):  # type: ignore[type-arg]
+class MatchesDict(OrderedDict[str | None, _V]):
     """
     A custom dict with matches property.
+
+    Generic over the value type: ``to_dict(enforce_list=True)`` returns a
+    ``MatchesDict[list[Any]]`` (every name maps to a list), the other modes a
+    ``MatchesDict[Any]`` (a name maps to a single value or a list, depending on
+    the matches).
     """
 
     def __init__(self) -> None:
@@ -714,7 +731,13 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
         """
         return self._tag_dict.keys()
 
-    def to_dict(self, details: bool = False, first_value: bool = False, enforce_list: bool = False) -> MatchesDict:
+    @overload
+    def to_dict(
+        self, details: bool = ..., first_value: bool = ..., *, enforce_list: Literal[True]
+    ) -> MatchesDict[list[Any]]: ...
+    @overload
+    def to_dict(self, details: bool = ..., first_value: bool = ..., enforce_list: bool = ...) -> MatchesDict[Any]: ...
+    def to_dict(self, details: bool = False, first_value: bool = False, enforce_list: bool = False) -> MatchesDict[Any]:
         """
         Converts matches to a dict object.
         :param details if True, values will be complete Match object, else it will be only string Match.value property
@@ -728,7 +751,7 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
         :return:
         :rtype: dict
         """
-        ret = MatchesDict()
+        ret: MatchesDict[Any] = MatchesDict()
         for match in sorted(self):
             value = match if details else match.value
             ret.matches[match.name].append(match)

--- a/rebulk/test/test_match.py
+++ b/rebulk/test/test_match.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -632,3 +632,7 @@ if TYPE_CHECKING:
         assert_type(matches.named("title", index=0), "Match | None")
         assert_type(matches.named("title", 0), "Match | None")
         assert_type(matches.named("title", lambda m: True), "list[Match]")
+
+    def _to_dict_reveal_types(matches: Matches) -> None:
+        # enforce_list=True -> every value is a list (predictable, typable)
+        assert_type(matches.to_dict(enforce_list=True)["x"], list[Any])


### PR DESCRIPTION
Implements #59 (v5 plan item 3.5 — additive, 4.x).

`to_dict()` returns a scalar *or* a list per name depending on the data — untypable. Per the #43 decision, `to_dict` stays first-class (guessit builds its public output on it), so this makes the *predictable* form typable instead of changing defaults:

- `MatchesDict` is now generic over its value type (and loses its `# type: ignore[type-arg]`).
- `to_dict` is overloaded: `to_dict(enforce_list=True)` → `MatchesDict[list[Any]]` (every name maps to a list); the other modes → `MatchesDict[Any]`.
- Default behaviour unchanged.
- README points to the typed retrieval API (`Key` / `Matches.to(...)`) for new code.

## Acceptance criteria (#59)
- [x] `to_dict(enforce_list=True)` has a precise, list-valued return type (overload + generic `MatchesDict`), verified with `assert_type`.
- [x] Default `to_dict()` behaviour unchanged (guessit compatibility).
- [x] README points to `to()` / `Key` as the typed path.
- [x] mypy --strict clean; tests green on both backends.

## Verification
- `mypy --strict`: clean
- `pytest`: 194 passed under both the `re` and `regex` backends
- `ruff` / full `pre-commit`: clean; coverage 98%

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)