### PR TITLE
refactor(chain)!: decouple Chain from Builder (v5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The library is built around a pipeline: **Patterns -> Matches -> Rules**.
   - `FunctionalPattern` - user-provided callable
   Each pattern produces `Match` objects and applies validators, formatters, and pre/post match processors.
 
-- **`chain.py` / `Chain`** - Ordered composition of patterns with repeaters (like regex quantifiers `?`, `*`, `+`, `{n,m}`). Also inherits from both `Pattern` and `Builder`.
+- **`chain.py` / `Chain`** - Ordered composition of patterns with repeaters (like regex quantifiers `?`, `*`, `+`, `{n,m}`). `Chain` is a `Pattern` (matchable); it is assembled through a `ChainBuilder` (in `builder.py`, returned by `Builder.chain()`), which appends `ChainPart` objects to it. (`Builder` and `ChainBuilder` share a `PatternFactory` base for the build/defaults machinery.)
 
 - **`match.py`** - `Match` (a single match with start/end/value/name/children) and `Matches` (a list with indexed lookups by name, tag, start, end position). `MatchesDict` converts matches to an OrderedDict.
 

--- a/docs/v5-design.md
+++ b/docs/v5-design.md
@@ -45,7 +45,13 @@ Everything below is **remaining** v5 work.
 
 Each item: **Problem → Proposed API (with before/after) → Breaking? → Effort → Migration.**
 
-### 3.1 Decouple `Chain` from `Builder` (architecture)
+### 3.1 Decouple `Chain` from `Builder` (architecture) — ✅ shipped (v5.0.0)
+
+**Status.** Implemented: `Chain` is now a plain `Pattern`; a new `ChainBuilder` (sharing a
+`PatternFactory` base with `Builder`) assembles it. The circular import and the Liskov
+`# type: ignore[override]` are gone, and the fluent chain is fully typed end to end. Breaking
+(`Chain` is no longer a `Builder`; `.chain()` returns a `ChainBuilder`) → cut in v5.0.0. The
+original analysis below is kept for reference.
 
 **Problem.** `class Chain(Pattern, Builder)` inherits from both, which:
 - forces a deferred `from .chain import Chain` inside `Builder.build_chain` (circular import);

--- a/rebulk/builder.py
+++ b/rebulk/builder.py
@@ -216,7 +216,7 @@ class ChainBuilder(PatternFactory):
     ``chain`` nests another chain and ``close`` returns the owning builder.
     """
 
-    def __init__(self, parent: Any, chain: Chain) -> None:
+    def __init__(self, parent: Builder | ChainBuilder, chain: Chain) -> None:
         super().__init__()
         self._parent = parent
         self._chain = chain

--- a/rebulk/builder.py
+++ b/rebulk/builder.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Base builder class for Rebulk
+Base builder classes for Rebulk
 """
 
 from __future__ import annotations
@@ -11,6 +11,7 @@ from copy import deepcopy
 from logging import getLogger
 from typing import TYPE_CHECKING, Any
 
+from .chain import Chain, ChainPart
 from .loose import set_defaults
 from .pattern import FunctionalPattern, RePattern, StringPattern
 
@@ -19,7 +20,6 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
-    from .chain import Chain
     from .key import Key
 
 log = getLogger(__name__).log
@@ -55,9 +55,12 @@ def overrides(kwargs: dict[str, Any]) -> Iterator[dict[str, Any]]:
     kwargs.update(backup)
 
 
-class Builder(metaclass=ABCMeta):
+class PatternFactory:
     """
-    Base builder class for patterns
+    Holds default keyword arguments and builds Pattern objects from them.
+
+    Shared by :class:`Builder` (the fluent pattern-registration API) and
+    :class:`ChainBuilder` (the fluent chain-assembly API).
     """
 
     def __init__(self) -> None:
@@ -67,32 +70,16 @@ class Builder(metaclass=ABCMeta):
         self._functional_defaults: dict[str, Any] = {}
         self._chain_defaults: dict[str, Any] = {}
 
-    def reset(self) -> None:
-        """
-        Reset all defaults.
-
-        :return:
-        """
-        self.__init__()  # type: ignore[misc]
-
     def defaults(self, **kwargs: Any) -> Self:
         """
         Define default keyword arguments for all patterns
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
         """
         set_defaults(kwargs, self._defaults, override=True)
         return self
 
     def regex_defaults(self, **kwargs: Any) -> Self:
         """
-        Define default keyword arguments for functional patterns.
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
+        Define default keyword arguments for regular expression patterns.
         """
         set_defaults(kwargs, self._regex_defaults, override=True)
         return self
@@ -100,10 +87,6 @@ class Builder(metaclass=ABCMeta):
     def string_defaults(self, **kwargs: Any) -> Self:
         """
         Define default keyword arguments for string patterns.
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
         """
         set_defaults(kwargs, self._string_defaults, override=True)
         return self
@@ -111,10 +94,6 @@ class Builder(metaclass=ABCMeta):
     def functional_defaults(self, **kwargs: Any) -> Self:
         """
         Define default keyword arguments for functional patterns.
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
         """
         set_defaults(kwargs, self._functional_defaults, override=True)
         return self
@@ -122,10 +101,6 @@ class Builder(metaclass=ABCMeta):
     def chain_defaults(self, **kwargs: Any) -> Self:
         """
         Define default keyword arguments for patterns chain.
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
         """
         set_defaults(kwargs, self._chain_defaults, override=True)
         return self
@@ -133,13 +108,6 @@ class Builder(metaclass=ABCMeta):
     def build_re(self, *pattern: Any, **kwargs: Any) -> RePattern:
         """
         Builds a new regular expression pattern
-
-        :param pattern:
-        :type pattern:
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
         """
         with overrides(kwargs):
             set_defaults(self._regex_defaults, kwargs)
@@ -150,13 +118,6 @@ class Builder(metaclass=ABCMeta):
     def build_string(self, *pattern: Any, **kwargs: Any) -> StringPattern:
         """
         Builds a new string pattern
-
-        :param pattern:
-        :type pattern:
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
         """
         with overrides(kwargs):
             set_defaults(self._string_defaults, kwargs)
@@ -167,13 +128,6 @@ class Builder(metaclass=ABCMeta):
     def build_functional(self, *pattern: Any, **kwargs: Any) -> FunctionalPattern:
         """
         Builds a new functional pattern
-
-        :param pattern:
-        :type pattern:
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
         """
         with overrides(kwargs):
             set_defaults(self._functional_defaults, kwargs)
@@ -183,29 +137,26 @@ class Builder(metaclass=ABCMeta):
 
     def build_chain(self, **kwargs: Any) -> Chain:
         """
-        Builds a new patterns chain
-
-        :param pattern:
-        :type pattern:
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
+        Builds a new (unregistered) patterns chain.
         """
-        from .chain import Chain
-
         with overrides(kwargs):
             set_defaults(self._chain_defaults, kwargs)
             set_defaults(self._defaults, kwargs)
 
-        chain = Chain(self, **kwargs)
-        chain._defaults = deepcopy(self._defaults)
-        chain._regex_defaults = deepcopy(self._regex_defaults)
-        chain._functional_defaults = deepcopy(self._functional_defaults)
-        chain._string_defaults = deepcopy(self._string_defaults)
-        chain._chain_defaults = deepcopy(self._chain_defaults)
+        return Chain(**kwargs)
 
-        return chain
+
+class Builder(PatternFactory, metaclass=ABCMeta):
+    """
+    Base fluent builder: registers patterns via :meth:`pattern` and exposes the
+    ``string`` / ``regex`` / ``functional`` / ``chain`` methods.
+    """
+
+    def reset(self) -> None:
+        """
+        Reset all defaults.
+        """
+        self.__init__()  # type: ignore[misc]
 
     @abstractmethod
     def pattern(self, *pattern: Any) -> Self:
@@ -219,11 +170,8 @@ class Builder(metaclass=ABCMeta):
         """
         Add re pattern
 
-        :param pattern:
-        :type pattern:
         :param key: optional typed key wiring up the match name and value type.
         :return: self
-        :rtype: Rebulk
         """
         return self.pattern(self.build_re(*pattern, **_apply_key(key, kwargs)))
 
@@ -231,11 +179,8 @@ class Builder(metaclass=ABCMeta):
         """
         Add string pattern
 
-        :param pattern:
-        :type pattern:
         :param key: optional typed key wiring up the match name and value type.
         :return: self
-        :rtype: Rebulk
         """
         return self.pattern(self.build_string(*pattern, **_apply_key(key, kwargs)))
 
@@ -243,26 +188,84 @@ class Builder(metaclass=ABCMeta):
         """
         Add functional pattern
 
-        :param pattern:
-        :type pattern:
         :param key: optional typed key wiring up the match name and value type.
         :return: self
-        :rtype: Rebulk
         """
-        functional = self.build_functional(*pattern, **_apply_key(key, kwargs))
-        return self.pattern(functional)
+        return self.pattern(self.build_functional(*pattern, **_apply_key(key, kwargs)))
 
-    def chain(self, **kwargs: Any) -> Chain:
+    def chain(self, **kwargs: Any) -> ChainBuilder:
         """
-        Add patterns chain, using configuration of this rebulk
+        Add a patterns chain, using configuration of this builder.
 
-        :param pattern:
-        :type pattern:
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
+        Returns a :class:`ChainBuilder` to assemble the chain parts; call
+        ``.close()`` to get back to this builder.
         """
         chain = self.build_chain(**kwargs)
         self.pattern(chain)
-        return chain
+        builder = ChainBuilder(self, chain)
+        builder._inherit_defaults(self)
+        return builder
+
+
+class ChainBuilder(PatternFactory):
+    """
+    Fluent builder for the parts of a :class:`~rebulk.chain.Chain`.
+
+    Each ``string`` / ``regex`` / ``functional`` call appends a
+    :class:`~rebulk.chain.ChainPart` (on which ``repeater`` can be called);
+    ``chain`` nests another chain and ``close`` returns the owning builder.
+    """
+
+    def __init__(self, parent: Any, chain: Chain) -> None:
+        super().__init__()
+        self._parent = parent
+        self._chain = chain
+
+    def _inherit_defaults(self, source: PatternFactory) -> None:
+        self._defaults = deepcopy(source._defaults)
+        self._regex_defaults = deepcopy(source._regex_defaults)
+        self._functional_defaults = deepcopy(source._functional_defaults)
+        self._string_defaults = deepcopy(source._string_defaults)
+        self._chain_defaults = deepcopy(source._chain_defaults)
+
+    def _add(self, pattern: Any) -> ChainPart:
+        part = ChainPart(self, pattern)
+        self._chain.parts.append(part)
+        return part
+
+    def regex(self, *pattern: Any, key: Key[Any] | None = None, **kwargs: Any) -> ChainPart:
+        """
+        Add a re pattern to the chain.
+        """
+        return self._add(self.build_re(*pattern, **_apply_key(key, kwargs)))
+
+    def string(self, *pattern: Any, key: Key[Any] | None = None, **kwargs: Any) -> ChainPart:
+        """
+        Add a string pattern to the chain.
+        """
+        return self._add(self.build_string(*pattern, **_apply_key(key, kwargs)))
+
+    def functional(self, *pattern: Any, key: Key[Any] | None = None, **kwargs: Any) -> ChainPart:
+        """
+        Add a functional pattern to the chain.
+        """
+        return self._add(self.build_functional(*pattern, **_apply_key(key, kwargs)))
+
+    def chain(self, **kwargs: Any) -> ChainBuilder:
+        """
+        Nest another chain as a part of this chain.
+        """
+        chain = self.build_chain(**kwargs)
+        self._add(chain)
+        nested = ChainBuilder(self, chain)
+        nested._inherit_defaults(self)
+        return nested
+
+    def close(self) -> Any:
+        """
+        Close the chain and return the owning (non-chain) builder.
+        """
+        parent = self._parent
+        while isinstance(parent, ChainBuilder):
+            parent = parent._parent
+        return parent

--- a/rebulk/chain.py
+++ b/rebulk/chain.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import itertools
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
-from .builder import Builder
 from .loose import call
 from .match import Match, Matches
 from .pattern import BasePattern, Pattern, filter_match_kwargs
@@ -17,6 +16,8 @@ from .remodule import re
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator
 
+    from .builder import ChainBuilder
+
 
 class _InvalidChainException(Exception):
     """
@@ -24,18 +25,20 @@ class _InvalidChainException(Exception):
     """
 
 
-class Chain(Pattern, Builder):
+class Chain(Pattern):
     """
     Definition of a pattern chain to search for.
+
+    A ``Chain`` is a matchable :class:`~rebulk.pattern.Pattern`. It is assembled
+    through a :class:`~rebulk.builder.ChainBuilder` (returned by ``Builder.chain``),
+    which appends :class:`ChainPart` instances to :attr:`parts`.
     """
 
     def __init__(
         self,
-        parent: Any,
         chain_breaker: Callable[[Matches], bool] | None = None,
         **kwargs: Any,
     ) -> None:
-        Builder.__init__(self)
         call(Pattern.__init__, self, **kwargs)
         self._kwargs = kwargs
         self._match_kwargs = filter_match_kwargs(kwargs)
@@ -44,32 +47,7 @@ class Chain(Pattern, Builder):
             self.chain_breaker = chain_breaker
         else:
             self.chain_breaker = None
-        self.parent = parent
         self.parts: list[ChainPart] = []
-
-    def pattern(self, *pattern: Any) -> ChainPart:  # type: ignore[override]
-        """
-
-        :param pattern:
-        :return:
-        """
-        if not pattern:
-            raise ValueError("One pattern should be given to the chain")
-        if len(pattern) > 1:
-            raise ValueError("Only one pattern can be given to the chain")
-        part = ChainPart(self, pattern[0])
-        self.parts.append(part)
-        return part
-
-    def close(self) -> Any:
-        """
-        Deeply close the chain
-        :return: Rebulk instance
-        """
-        parent = self.parent
-        while isinstance(parent, Chain):
-            parent = parent.parent
-        return parent
 
     def _match(
         self,
@@ -243,12 +221,16 @@ class ChainPart(BasePattern):
     Part of a pattern chain.
     """
 
-    def __init__(self, chain: Chain, pattern: Any) -> None:
-        self._chain = chain
+    def __init__(self, builder: ChainBuilder, pattern: Any) -> None:
+        self._builder = builder
         self.pattern = pattern
         self.repeater_start: int = 1
         self.repeater_end: int | None = 1
         self._hidden = False
+
+    @property
+    def _chain(self) -> Chain:
+        return self._builder._chain
 
     @property
     def _is_chain_start(self) -> bool:
@@ -324,14 +306,11 @@ class ChainPart(BasePattern):
         if max_match_index + 1 < self.repeater_start:
             raise _InvalidChainException
 
-    def chain(self) -> Chain:
+    def chain(self) -> ChainBuilder:
         """
-        Add patterns chain, using configuration from this chain
-
-        :return:
-        :rtype:
+        Nest another patterns chain, using configuration from this chain.
         """
-        return self._chain.chain()
+        return self._builder.chain()
 
     def hidden(self, hidden: bool = True) -> ChainPart:
         """
@@ -356,44 +335,21 @@ class ChainPart(BasePattern):
 
     def regex(self, *pattern: Any, **kwargs: Any) -> ChainPart:
         """
-        Add re pattern
-
-        :param pattern:
-        :type pattern:
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
+        Add re pattern to the chain.
         """
-        # The builder's regex/string/functional are typed `-> Self` (Chain), but
-        # Chain.pattern() yields a ChainPart, which is what is actually returned.
-        return cast("ChainPart", self._chain.regex(*pattern, **kwargs))
+        return self._builder.regex(*pattern, **kwargs)
 
     def functional(self, *pattern: Any, **kwargs: Any) -> ChainPart:
         """
-        Add functional pattern
-
-        :param pattern:
-        :type pattern:
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
+        Add functional pattern to the chain.
         """
-        return cast("ChainPart", self._chain.functional(*pattern, **kwargs))
+        return self._builder.functional(*pattern, **kwargs)
 
     def string(self, *pattern: Any, **kwargs: Any) -> ChainPart:
         """
-        Add string pattern
-
-        :param pattern:
-        :type pattern:
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
+        Add string pattern to the chain.
         """
-        return cast("ChainPart", self._chain.string(*pattern, **kwargs))
+        return self._builder.string(*pattern, **kwargs)
 
     def close(self) -> Any:
         """
@@ -402,7 +358,7 @@ class ChainPart(BasePattern):
         :return:
         :rtype:
         """
-        return self._chain.close()
+        return self._builder.close()
 
     def repeater(self, value: Any) -> ChainPart:
         """

--- a/rebulk/test/test_chain.py
+++ b/rebulk/test/test_chain.py
@@ -116,7 +116,7 @@ def test_chain_with_validators() -> None:
 
 def test_matches_docs() -> None:
     rebulk = (
-        Rebulk()  # type: ignore[attr-defined]
+        Rebulk()
         .regex_defaults(flags=re.IGNORECASE)
         .defaults(children=True, formatter={"episode": int, "version": int})
         .chain()
@@ -149,7 +149,7 @@ def test_matches() -> None:
     input_string = "1849testtestxxfixfux_foxabc1849testtestxoptionalfoxabc"
 
     chain = (
-        rebulk.chain()  # type: ignore[attr-defined]
+        rebulk.chain()
         .functional(digit)
         .string("test")
         .hidden()
@@ -215,7 +215,7 @@ def test_matches() -> None:
 
 def test_matches_2() -> None:
     rebulk = (
-        Rebulk()  # type: ignore[attr-defined]
+        Rebulk()
         .regex_defaults(flags=re.IGNORECASE)
         .defaults(children=True, formatter={"episode": int, "version": int})
         .chain()

--- a/rebulk/test/test_chain.py
+++ b/rebulk/test/test_chain.py
@@ -509,3 +509,17 @@ def test_group_by_match_index_sorts_unordered_input() -> None:
     assert [m.start for m in grouped[1]] == [10]
     # both match_index=2 matches are kept, in their original relative order
     assert [m.start for m in grouped[2]] == [0, 15]
+
+
+def test_nested_chain() -> None:
+    # A chain whose single part is itself a chain (a then b), matched end to end.
+    rebulk = Rebulk()
+    nested = rebulk.chain(children=True).chain()
+    nested.regex(r"(?P<a>a)").regex(r"(?P<b>b)")
+
+    assert nested.close() is rebulk
+
+    matches = rebulk.matches("ab")
+
+    assert [m.value for m in matches.named("a")] == ["a"]
+    assert [m.value for m in matches.named("b")] == ["b"]


### PR DESCRIPTION
Implements #60 (v5 plan item 3.1). **Breaking → cuts v5.0.0.**

## What
`Chain` is now a plain `Pattern`. A new `ChainBuilder` (sharing a `PatternFactory` base with `Builder`) assembles it. `Builder.chain()` returns a `ChainBuilder`; its `regex/string/functional` append a `ChainPart` and return it.

This:
- **removes the circular import** that forced a deferred `from .chain import Chain` in `build_chain` (now `builder.py` imports `chain.py` at top; `chain.py` imports `ChainBuilder` only under `TYPE_CHECKING`);
- **drops the Liskov `# type: ignore[override]`** on the chain fluent API (`ChainBuilder` doesn't override `Builder.pattern`);
- makes the **fluent chain fully typed end to end** (`.chain() -> ChainBuilder`, `.regex() -> ChainPart`, `.repeater() -> ChainPart`, …) — three now-unused `type: ignore` in the tests were removed, confirming it.

The matching engine (`_match`, `_build_chain_match`, …) is unchanged.

## Runtime compatibility
The documented fluent API is **identical at runtime**: `rebulk.chain().regex(...).repeater(...).string(...).close()`, including the guessit idiom `rebulk.chain(...).defaults(...).regex(...)` and nested chains. Verified with a smoke test (chains, nested chains, `close()` → Rebulk, no circular import) and the full `test_chain.py`. guessit uses `.chain()` purely fluently, so it is unaffected at runtime.

## Breaking changes
- `Chain` is no longer a `Builder` subclass.
- `Builder.chain()` returns a `ChainBuilder`, not a `Chain`.

Only affects code relying on `isinstance(chain, Builder)` or annotating the `.chain()` result as `Chain`. (`Chain` is not in `rebulk.__all__`.)

## Verification
- `mypy --strict`: clean (no more chain `type: ignore[override]`)
- `pytest`: 194 passed under both the `re` and `regex` backends
- `ruff` / full `pre-commit`: clean; coverage 97%
- Docs updated: `CLAUDE.md` architecture note + `docs/v5-design.md` §3.1 marked shipped

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)