### PR TITLE
feat(key): support children patterns via keys= and declare_keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,40 @@ datetime.date(2008, 1, 2)
 
 ```
 
+A single `key=` wires one match name and formatter. For a `children=True`
+pattern that exposes several named groups, pass `keys=` instead: each key's
+converter is registered under its name as a per-name formatter, and an explicit
+per-pattern `formatter` entry still overrides it.
+
+```python
+>>> season = Key("season", int)
+>>> episode = Key("episode", int)
+>>> matches = Rebulk().regex(r'S(?P<season>\d+)E(?P<episode>\d+)',
+...                          keys=[season, episode], children=True) \
+...                   .matches("Show.S03E07.mkv")
+>>> matches[season]
+3
+>>> matches[episode]
+7
+
+```
+
+To avoid repeating the same per-name formatters across many patterns, declare
+the keys once on the builder with `declare_keys`. Every pattern built afterwards
+inherits each key's converter as a per-name formatter for the matching group
+name; a pattern that defines its own formatter for that name still overrides it,
+so formatter variance across patterns is preserved.
+
+```python
+>>> rb = Rebulk().declare_keys(season, episode)
+>>> _ = rb.regex(r'S(?P<season>\d+)E(?P<episode>\d+)', children=True)   # inherits int, int
+>>> _ = rb.regex(r'(?P<season>\d+)x(?P<episode>\d+)', children=True)    # inherits int, int
+>>> matches = rb.matches("Show.S03E07.mkv")
+>>> matches[season], matches[episode]
+(3, 7)
+
+```
+
 You can also project the matches onto a typed dataclass with `to`. Each field
 is filled from matches sharing its name: a `list[...]` field collects all
 values, any other field takes the first, and unmatched fields fall back to

--- a/rebulk/builder.py
+++ b/rebulk/builder.py
@@ -9,20 +9,23 @@ from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from copy import deepcopy
 from logging import getLogger
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from .chain import Chain, ChainPart
+from .formatters import default_formatter
 from .loose import set_defaults
-from .pattern import FunctionalPattern, RePattern, StringPattern
+from .pattern import FunctionalPattern, Pattern, RePattern, StringPattern
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Sequence
 
     from typing_extensions import Self
 
     from .key import Key
 
 log = getLogger(__name__).log
+
+_P = TypeVar("_P", bound=Pattern)
 
 
 def _apply_key(key: Key[Any] | None, kwargs: dict[str, Any]) -> dict[str, Any]:
@@ -34,6 +37,33 @@ def _apply_key(key: Key[Any] | None, kwargs: dict[str, Any]) -> dict[str, Any]:
     if key is not None:
         kwargs.setdefault("name", key.name)
         kwargs.setdefault("formatter", key.converter)
+    return kwargs
+
+
+def _apply_keys(keys: Sequence[Key[Any]] | None, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """
+    Inject several typed :class:`~rebulk.key.Key` as a per-name ``formatter``
+    dict, composing with ``children=True`` patterns that expose several named
+    groups (e.g. ``(?P<season>\\d+)(?P<episode>\\d+)``).
+
+    Each key's converter is registered under its ``name``; explicit per-name
+    entries already present in ``formatter`` are preserved (a per-pattern
+    formatter still wins over the key's converter).
+    """
+    if keys:
+        formatter = kwargs.get("formatter")
+        if formatter is None:
+            formatter = {}
+        elif isinstance(formatter, dict):
+            formatter = dict(formatter)  # copy: never mutate the caller's dict
+        else:
+            raise TypeError(
+                "keys= builds a per-name formatter dict and cannot be combined with a single "
+                "formatter callable; pass a per-name formatter dict or drop the explicit formatter"
+            )
+        for key in keys:
+            formatter.setdefault(key.name, key.converter)
+        kwargs["formatter"] = formatter
     return kwargs
 
 
@@ -69,6 +99,40 @@ class PatternFactory:
         self._string_defaults: dict[str, Any] = {}
         self._functional_defaults: dict[str, Any] = {}
         self._chain_defaults: dict[str, Any] = {}
+        self._keys: dict[str, Key[Any]] = {}
+
+    def declare_keys(self, *keys: Key[Any]) -> Self:
+        """
+        Declare typed :class:`~rebulk.key.Key` once for this builder.
+
+        Every pattern built afterwards inherits each key's converter as a
+        per-name formatter for the matching group name, unless it defines its
+        own formatter for that name (an explicit per-pattern formatter still
+        wins). This gives a single source of truth for the common conversion of
+        named groups exposed by ``children=True`` patterns, while per-pattern
+        overrides preserve formatter variance across patterns.
+        """
+        for key in keys:
+            self._keys[key.name] = key
+        return self
+
+    def _inherit_keys(self, pattern: _P) -> _P:
+        """
+        Enrich a freshly built pattern with the declared keys' converters as
+        per-name formatters, without overriding any formatter it already defines.
+
+        A pattern that supplies its own formatter for a name keeps it: explicit
+        per-name entries take precedence, and a single bare-callable formatter
+        (whose ``_default_formatter`` differs from the library default) is left
+        untouched entirely. Enrichment writes to a fresh dict so the shared
+        ``defaults(formatter=...)`` / caller-owned dict is never mutated in place.
+        """
+        if not self._keys or pattern._default_formatter is not default_formatter:
+            return pattern
+        missing = {key.name: key.converter for key in self._keys.values() if key.name not in pattern.formatters}
+        if missing:
+            pattern.formatters = {**pattern.formatters, **missing}
+        return pattern
 
     def defaults(self, **kwargs: Any) -> Self:
         """
@@ -113,7 +177,7 @@ class PatternFactory:
             set_defaults(self._regex_defaults, kwargs)
             set_defaults(self._defaults, kwargs)
 
-        return RePattern(*pattern, **kwargs)
+        return self._inherit_keys(RePattern(*pattern, **kwargs))
 
     def build_string(self, *pattern: Any, **kwargs: Any) -> StringPattern:
         """
@@ -123,7 +187,7 @@ class PatternFactory:
             set_defaults(self._string_defaults, kwargs)
             set_defaults(self._defaults, kwargs)
 
-        return StringPattern(*pattern, **kwargs)
+        return self._inherit_keys(StringPattern(*pattern, **kwargs))
 
     def build_functional(self, *pattern: Any, **kwargs: Any) -> FunctionalPattern:
         """
@@ -133,7 +197,7 @@ class PatternFactory:
             set_defaults(self._functional_defaults, kwargs)
             set_defaults(self._defaults, kwargs)
 
-        return FunctionalPattern(*pattern, **kwargs)
+        return self._inherit_keys(FunctionalPattern(*pattern, **kwargs))
 
     def build_chain(self, **kwargs: Any) -> Chain:
         """
@@ -143,7 +207,7 @@ class PatternFactory:
             set_defaults(self._chain_defaults, kwargs)
             set_defaults(self._defaults, kwargs)
 
-        return Chain(**kwargs)
+        return self._inherit_keys(Chain(**kwargs))
 
 
 class Builder(PatternFactory, metaclass=ABCMeta):
@@ -166,32 +230,44 @@ class Builder(PatternFactory, metaclass=ABCMeta):
         :return:
         """
 
-    def regex(self, *pattern: Any, key: Key[Any] | None = None, **kwargs: Any) -> Self:
+    def regex(
+        self, *pattern: Any, key: Key[Any] | None = None, keys: Sequence[Key[Any]] | None = None, **kwargs: Any
+    ) -> Self:
         """
         Add re pattern
 
         :param key: optional typed key wiring up the match name and value type.
+        :param keys: optional typed keys wiring up a per-name formatter dict, for
+            ``children=True`` patterns exposing several named groups.
         :return: self
         """
-        return self.pattern(self.build_re(*pattern, **_apply_key(key, kwargs)))
+        return self.pattern(self.build_re(*pattern, **_apply_keys(keys, _apply_key(key, kwargs))))
 
-    def string(self, *pattern: Any, key: Key[Any] | None = None, **kwargs: Any) -> Self:
+    def string(
+        self, *pattern: Any, key: Key[Any] | None = None, keys: Sequence[Key[Any]] | None = None, **kwargs: Any
+    ) -> Self:
         """
         Add string pattern
 
         :param key: optional typed key wiring up the match name and value type.
+        :param keys: optional typed keys wiring up a per-name formatter dict, for
+            ``children=True`` patterns exposing several named groups.
         :return: self
         """
-        return self.pattern(self.build_string(*pattern, **_apply_key(key, kwargs)))
+        return self.pattern(self.build_string(*pattern, **_apply_keys(keys, _apply_key(key, kwargs))))
 
-    def functional(self, *pattern: Any, key: Key[Any] | None = None, **kwargs: Any) -> Self:
+    def functional(
+        self, *pattern: Any, key: Key[Any] | None = None, keys: Sequence[Key[Any]] | None = None, **kwargs: Any
+    ) -> Self:
         """
         Add functional pattern
 
         :param key: optional typed key wiring up the match name and value type.
+        :param keys: optional typed keys wiring up a per-name formatter dict, for
+            ``children=True`` patterns exposing several named groups.
         :return: self
         """
-        return self.pattern(self.build_functional(*pattern, **_apply_key(key, kwargs)))
+        return self.pattern(self.build_functional(*pattern, **_apply_keys(keys, _apply_key(key, kwargs))))
 
     def chain(self, **kwargs: Any) -> ChainBuilder:
         """
@@ -227,29 +303,36 @@ class ChainBuilder(PatternFactory):
         self._functional_defaults = deepcopy(source._functional_defaults)
         self._string_defaults = deepcopy(source._string_defaults)
         self._chain_defaults = deepcopy(source._chain_defaults)
+        self._keys = dict(source._keys)
 
     def _add(self, pattern: Any) -> ChainPart:
         part = ChainPart(self, pattern)
         self._chain.parts.append(part)
         return part
 
-    def regex(self, *pattern: Any, key: Key[Any] | None = None, **kwargs: Any) -> ChainPart:
+    def regex(
+        self, *pattern: Any, key: Key[Any] | None = None, keys: Sequence[Key[Any]] | None = None, **kwargs: Any
+    ) -> ChainPart:
         """
         Add a re pattern to the chain.
         """
-        return self._add(self.build_re(*pattern, **_apply_key(key, kwargs)))
+        return self._add(self.build_re(*pattern, **_apply_keys(keys, _apply_key(key, kwargs))))
 
-    def string(self, *pattern: Any, key: Key[Any] | None = None, **kwargs: Any) -> ChainPart:
+    def string(
+        self, *pattern: Any, key: Key[Any] | None = None, keys: Sequence[Key[Any]] | None = None, **kwargs: Any
+    ) -> ChainPart:
         """
         Add a string pattern to the chain.
         """
-        return self._add(self.build_string(*pattern, **_apply_key(key, kwargs)))
+        return self._add(self.build_string(*pattern, **_apply_keys(keys, _apply_key(key, kwargs))))
 
-    def functional(self, *pattern: Any, key: Key[Any] | None = None, **kwargs: Any) -> ChainPart:
+    def functional(
+        self, *pattern: Any, key: Key[Any] | None = None, keys: Sequence[Key[Any]] | None = None, **kwargs: Any
+    ) -> ChainPart:
         """
         Add a functional pattern to the chain.
         """
-        return self._add(self.build_functional(*pattern, **_apply_key(key, kwargs)))
+        return self._add(self.build_functional(*pattern, **_apply_keys(keys, _apply_key(key, kwargs))))
 
     def chain(self, **kwargs: Any) -> ChainBuilder:
         """

--- a/rebulk/test/test_key.py
+++ b/rebulk/test/test_key.py
@@ -5,6 +5,7 @@ Tests for typed Key retrieval (POC for type-safe value access).
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import date
 from typing import TYPE_CHECKING, TypedDict
@@ -76,6 +77,166 @@ def test_key_multiple_values() -> None:
 
     assert matches.all(digit) == [1, 2, 3]
     assert matches[digit] == 1
+
+
+def test_keys_children_per_name_formatter() -> None:
+    season = Key("season", int)
+    episode = Key("episode", int)
+
+    bulk = Rebulk().regex(r"S(?P<season>\d+)E(?P<episode>\d+)", keys=[season, episode], children=True)
+    matches = bulk.matches("Show.S03E07.mkv")
+
+    assert matches[season] == 3
+    assert matches[episode] == 7
+
+
+def test_keys_multiple_children_values() -> None:
+    season = Key("season", int)
+    episode = Key("episode", int)
+
+    bulk = Rebulk().regex(
+        r"S(?P<season>\d+)(?:E(?P<episode>\d+))+",
+        keys=[season, episode],
+        children=True,
+    )
+    matches = bulk.matches("Show.S03E07.mkv")
+
+    assert matches[season] == 3
+    assert matches.all(episode) == [7]
+
+
+def test_keys_preserve_explicit_per_name_formatter() -> None:
+    season = Key("season", int)
+    episode = Key("episode", str)
+
+    # An explicit per-name formatter wins over the key converter (variance preserved):
+    # the key would apply plain str, the override upper-cases instead.
+    bulk = Rebulk().regex(
+        r"S(?P<season>\d+)E(?P<episode>\w+)",
+        keys=[season, episode],
+        formatter={"episode": str.upper},
+        children=True,
+    )
+    matches = bulk.matches("Show.S03Eab.mkv")
+
+    assert matches[season] == 3
+    assert matches[episode] == "AB"
+
+
+def test_keys_rejects_single_formatter_callable() -> None:
+    season = Key("season", int)
+
+    with pytest.raises(TypeError, match=r"per-name formatter"):
+        Rebulk().regex(r"(?P<season>\d+)", keys=[season], formatter=int, children=True)
+
+
+def test_keys_none_is_noop() -> None:
+    year = Key("year", int)
+    matches = Rebulk().regex(r"\d{4}", key=year, keys=None).matches("born in 1984")
+
+    assert matches[year] == 1984
+
+
+def test_declare_keys_inherited_per_name_formatter() -> None:
+    season = Key("season", int)
+    episode = Key("episode", int)
+
+    bulk = Rebulk().declare_keys(season, episode)
+    # No keys=/formatter= on the pattern: the converters are inherited from the registry.
+    bulk.regex(r"S(?P<season>\d+)E(?P<episode>\d+)", children=True)
+    matches = bulk.matches("Show.S03E07.mkv")
+
+    assert matches[season] == 3
+    assert matches[episode] == 7
+
+
+def test_declare_keys_inherited_on_named_parent() -> None:
+    year = Key("year", int)
+
+    bulk = Rebulk().declare_keys(year).regex(r"\d{4}", name="year")
+    matches = bulk.matches("born in 1984")
+
+    assert matches[year] == 1984
+
+
+def test_declare_keys_explicit_formatter_overrides_registry() -> None:
+    season = Key("season", int)
+    episode = Key("episode", int)
+
+    bulk = Rebulk().declare_keys(season, episode)
+    # roman/CJK-like pattern: a per-pattern formatter for episode wins over the registry int.
+    bulk.regex(
+        r"S(?P<season>\d+)E(?P<episode>\w+)",
+        formatter={"episode": lambda s: len(s)},
+        children=True,
+    )
+    matches = bulk.matches("Show.S03Eabcd.mkv")
+
+    assert matches[season] == 3
+    assert matches.all(episode) == [4]
+
+
+def test_declare_keys_bare_callable_formatter_wins() -> None:
+    # A single bare-callable formatter is the pattern's explicit choice and must
+    # win over the registry converter (variance preserved, even without a dict).
+    year = Key("year", int)
+    bulk = Rebulk().declare_keys(year).regex(r"\d{4}", name="year", formatter=lambda s: f"Y{s}")
+    matches = bulk.matches("born in 1984")
+
+    assert matches[0].value == "Y1984"
+
+
+def test_declare_keys_does_not_mutate_shared_default_formatter() -> None:
+    season = Key("season", int)
+    shared = {"x": str.upper}
+    bulk = Rebulk().declare_keys(season).defaults(formatter=shared)
+    bulk.regex(r"(?P<season>\d+)", children=True)
+
+    # The caller-owned dict and the stored default must stay pristine.
+    assert shared == {"x": str.upper}
+    assert "season" not in bulk._defaults["formatter"]
+
+
+def test_keys_does_not_mutate_caller_formatter_dict() -> None:
+    season = Key("season", int)
+    episode = Key("episode", int)
+    shared = {"episode": str.upper}
+    Rebulk().regex(r"S(?P<season>\d+)E(?P<episode>\w+)", keys=[season, episode], formatter=shared, children=True)
+
+    # keys= must not leak the season converter into the caller's dict.
+    assert shared == {"episode": str.upper}
+
+
+def test_declare_keys_returns_self_for_chaining() -> None:
+    year = Key("year", int)
+    bulk = Rebulk()
+    assert bulk.declare_keys(year) is bulk
+
+
+def test_declare_keys_inherited_in_chain() -> None:
+    episode = Key("episode", int)
+    version = Key("version", int)
+
+    # The ticket's motivating example: declare_keys replaces the repeated
+    # formatter={"episode": int, "version": int} on the chain.
+    rebulk = (
+        Rebulk()
+        .declare_keys(episode, version)
+        .regex_defaults(flags=re.IGNORECASE)
+        .defaults(children=True)
+        .chain()
+        .regex(r"e(?P<episode>\d{1,4})")
+        .repeater(1)
+        .regex(r"v(?P<version>\d+)")
+        .repeater("?")
+        .regex(r"[ex-](?P<episode>\d{1,4})")
+        .repeater("*")
+        .close()
+    )
+    matches = rebulk.matches("This is E14v2-15-16-17")
+
+    assert matches.all(episode) == [14, 15, 16, 17]
+    assert matches[version] == 2
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Contexte

Le `Key` typé (v5) câblait un seul `name` + `formatter` via `key=`, mais ne composait pas avec les patterns `children=True` exposant plusieurs groupes nommés (la forme dominante du core *episodes* de guessit). Implémente les deux tiers proposés dans #65.

## Tier 1 — `keys=` pluriel

Construit un dict `formatter` par-nom sur un pattern, composant avec `children=True` sans écraser les entrées explicites :

```python
rb.regex(r"(?P<season>\d+)(?P<episode>\d+)", keys=[SEASON, EPISODE], children=True)
```

## Tier 2 — registre `declare_keys()` + héritage par-nom

Déclare les keys une fois sur le builder ; chaque pattern construit ensuite hérite du converter de la key comme formatter par-nom du groupe correspondant. Un formatter explicite par-pattern (dict par-nom **ou** callable nu) l'emporte sur le registre, préservant la variance des formatters entre patterns (cas roman / CJK).

```python
rb = Rebulk().declare_keys(SEASON, EPISODE, VERSION, COUNT)
rb.regex(r"S(?P<season>\d+)E(?P<episode>\d+)", children=True)  # hérite int, int
```

Choix de design : la logique vit côté builder (pas dans `Pattern.__init__`), gardant `Pattern` découplé du concept de `Key`, cohérent avec le refactor récent *decouple Chain from Builder*. L'enrichissement écrit dans un dict frais, sans jamais muter le `defaults(formatter=...)` partagé ni le dict de l'appelant.

## Revue de code intégrée

Une revue (high effort) a remonté 3 problèmes, tous corrigés avant le commit :
1. **(haut)** un `formatter=` callable nu était silencieusement écrasé par le registre → garde sur `_default_formatter`, le formatter explicite gagne désormais dans tous les cas.
2. **(moyen)** `_inherit_keys` mutait le dict `defaults(formatter=...)` partagé → écriture dans un dict frais.
3. **(bas)** `_apply_keys` mutait le dict `formatter=` de l'appelant → copie défensive.

## Tests

19 tests dans `test_key.py` (children, valeurs multiples, override de variance, callable nu préservé, non-mutation des dicts, héritage en chain, chaînage). Suite complète : **208 passed** sous `re` **et** `REBULK_REGEX_ENABLED=1`, mypy strict clean, ruff clean, doctests README inclus.

## Hors scope

L'usage des `value_type` déclarés dans `matches.to(Model)`/introspection et l'assertion debug de cohérence de type (marqués « optionnels » dans #65) ne sont pas câblés — follow-up possible.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4Ryxr6Fc7sCERn6WChpqv