### PR TITLE
feat(key): leverage declared keys for typed output projection in to()

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,25 @@ or `TypedDict` is rejected, as a flat match sequence has no record grouping.
 
 ```
 
+Keys declared with `declare_keys` are carried on the resulting `Matches` (as
+`matches.declared_keys`) and used by `to` to close the typing loop: a model
+field whose type contradicts the declared `value_type` of a key with the same
+name raises `TypeError`, instead of silently building an ill-typed result. A
+`list[...]` field is checked against the declared *element* type, and fields
+with no matching declared key are left untouched.
+
+```python
+>>> @dataclass
+... class Wrong:
+...     season: str   # declared as int by the key above
+>>> Rebulk().declare_keys(season).regex(r'S(?P<season>\d+)', children=True) \
+...        .matches("S03").to(Wrong)
+Traceback (most recent call last):
+    ...
+TypeError: Wrong field 'season' typed <class 'str'> contradicts declared key 'season' of value_type <class 'int'>
+
+```
+
 Markers
 =======
 

--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -10,11 +10,13 @@ import dataclasses
 import itertools
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable, Iterable, KeysView, MutableSequence
+from types import UnionType
 from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
     TypeVar,
+    Union,
     cast,
     get_args,
     get_origin,
@@ -34,6 +36,46 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 M = TypeVar("M")
 _V = TypeVar("_V")
+
+
+def _element_type(hint: Any) -> type | None:
+    """
+    Resolve the *element* type carried by a model field annotation, or ``None``
+    when it cannot be pinned to a single concrete type.
+
+    ``list[X]`` resolves to ``X`` (the element a declared key types), an
+    ``Optional[X]`` / ``X | None`` to ``X``, and a bare scalar ``type`` to
+    itself. Anything else (bare ``Union`` of several types, an unparameterized
+    container such as ``list`` / ``dict``, other generics, type vars) yields
+    ``None`` so the caller skips the cross-check rather than guessing.
+    """
+    if hint is Any:
+        return None
+    origin = get_origin(hint)
+    if origin is list:
+        args = get_args(hint)
+        return _element_type(args[0]) if args else None
+    if origin is Union or origin is UnionType:
+        non_none = [arg for arg in get_args(hint) if arg is not type(None)]
+        return _element_type(non_none[0]) if len(non_none) == 1 else None
+    if isinstance(hint, type) and not issubclass(hint, (list, tuple, set, frozenset, dict)):
+        return hint
+    return None
+
+
+def _contradicts(hint: Any, declared: type) -> bool:
+    """
+    True when a model field annotation contradicts a declared key ``value_type``.
+
+    The element types must be related by subclassing in either direction (so a
+    ``date`` key matches a ``datetime`` field and vice versa); unrelated concrete
+    types (``int`` vs ``str``) contradict. Unresolvable annotations never
+    contradict.
+    """
+    element = _element_type(hint)
+    if element is None:
+        return False
+    return not (issubclass(element, declared) or issubclass(declared, element))
 
 
 class MatchesDict(OrderedDict[str | None, _V]):
@@ -64,6 +106,7 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
 
     def __init__(self, matches: Iterable[Match] | None = None, input_string: str | None = None) -> None:
         self.input_string = input_string
+        self.declared_keys: dict[str, Key[Any]] = {}
         self._max_end = 0
         self._delegate: list[Match] = []
         self.__name_dict: dict[str | None, list[Match]] | None = None
@@ -822,6 +865,13 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
         The result is typed end to end via ``def to(self, model: type[M]) -> M``.
         Values are used as produced by each pattern's formatter (see ``key=`` /
         ``formatter=``); ``to`` does not coerce them.
+
+        When the builder declared keys (``declare_keys``), they are carried on the
+        :class:`Matches` as :attr:`declared_keys` and cross-checked here: a
+        dataclass / ``TypedDict`` field whose (element) type contradicts the
+        declared ``value_type`` of a key with the same name raises ``TypeError``,
+        closing the typing loop from the build-time declaration to the projected
+        value. Fields with no matching declared key are left untouched.
         """
         if get_origin(model) is list:
             (item_type,) = get_args(model) or (object,)
@@ -846,8 +896,15 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
             raise TypeError(f"{model!r} is not a dataclass, TypedDict, primitive or list type")
         kwargs: dict[str, Any] = {}
         for name in field_names:
+            hint = hints.get(name)
+            declared = self.declared_keys.get(name)
+            if declared is not None and _contradicts(hint, declared.value_type):
+                raise TypeError(
+                    f"{model.__name__} field {name!r} typed {hint!r} contradicts "
+                    f"declared key {name!r} of value_type {declared.value_type!r}"
+                )
             values = [match.value for match in self._name_dict[name]]
-            if get_origin(hints.get(name)) is list:
+            if get_origin(hint) is list:
                 kwargs[name] = values
             elif values:
                 kwargs[name] = values[0]

--- a/rebulk/rebulk.py
+++ b/rebulk/rebulk.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
+    from .key import Key
     from .pattern import Pattern
 
 log = getLogger(__name__).log
@@ -123,6 +124,9 @@ class Rebulk(Builder):
         if context is None:
             context = {}
 
+        if not self.disabled(context):
+            matches.declared_keys = self.effective_keys(context)
+
         self._matches_patterns(matches, context)
 
         self._execute_rules(matches, context)
@@ -143,6 +147,24 @@ class Rebulk(Builder):
             if not rebulk.disabled(context):
                 extend_safe(rules, rebulk._rules)
         return rules
+
+    def effective_keys(self, context: dict[str, Any] | None = None) -> dict[str, Key[Any]]:
+        """
+        Get effective declared keys for this rebulk object and its children.
+
+        Keys declared on a child rebulk are merged in (without overriding the
+        parent's), so the returned registry mirrors the patterns actually run.
+        :param context:
+        :type context:
+        :return:
+        :rtype:
+        """
+        keys: dict[str, Key[Any]] = dict(self._keys)
+        for rebulk in self._rebulks:
+            if not rebulk.disabled(context):
+                for name, key in rebulk._keys.items():
+                    keys.setdefault(name, key)
+        return keys
 
     def _execute_rules(self, matches: Matches, context: dict[str, Any]) -> None:
         """

--- a/rebulk/test/test_key.py
+++ b/rebulk/test/test_key.py
@@ -239,6 +239,46 @@ def test_declare_keys_inherited_in_chain() -> None:
     assert matches[version] == 2
 
 
+def test_declared_keys_carried_on_matches() -> None:
+    season = Key("season", int)
+    episode = Key("episode", int)
+
+    matches = Rebulk().declare_keys(season, episode).matches("Show.S03E07.mkv")
+
+    assert matches.declared_keys == {"season": season, "episode": episode}
+
+
+def test_declared_keys_empty_without_declaration() -> None:
+    # key= wires a pattern but does not populate the declared registry.
+    year = Key("year", int)
+    matches = Rebulk().regex(r"\d{4}", key=year).matches("1984")
+
+    assert matches.declared_keys == {}
+
+
+def test_effective_keys_merges_children() -> None:
+    season = Key("season", int)
+    episode = Key("episode", int)
+
+    child = Rebulk().declare_keys(episode)
+    parent = Rebulk().declare_keys(season).rebulk(child)
+
+    assert parent.effective_keys() == {"season": season, "episode": episode}
+
+    # Effective keys flow onto the produced Matches too.
+    matches = parent.matches("nothing")
+    assert matches.declared_keys == {"season": season, "episode": episode}
+
+
+def test_effective_keys_parent_wins_over_child() -> None:
+    parent_key = Key("dup", int)
+    child_key = Key("dup", str)
+
+    parent = Rebulk().declare_keys(parent_key).rebulk(Rebulk().declare_keys(child_key))
+
+    assert parent.effective_keys() == {"dup": parent_key}
+
+
 if TYPE_CHECKING:
 
     def _reveal_types() -> None:

--- a/rebulk/test/test_model.py
+++ b/rebulk/test/test_model.py
@@ -6,11 +6,13 @@ Tests for typed result models via Matches.to(dataclass) (v5 POC).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, TypedDict
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any, Optional, TypedDict
 
 import pytest
 
 from ..key import Key
+from ..match import _contradicts
 from ..rebulk import Rebulk
 
 if TYPE_CHECKING:
@@ -116,6 +118,119 @@ def test_to_rejects_non_type() -> None:
     matches = Rebulk().string("x").matches("x")
     with pytest.raises(TypeError, match="not a dataclass"):
         matches.to(42)  # type: ignore[arg-type]
+
+
+def test_to_model_contradicting_declared_key_raises() -> None:
+    @dataclass
+    class Wrong:
+        year: str  # declared key types year as int
+
+    year = Key("year", int)
+    matches = Rebulk().declare_keys(year).regex(r"\d{4}", name="year").matches("1984")
+    with pytest.raises(TypeError, match="contradicts declared key"):
+        matches.to(Wrong)
+
+
+def test_to_typeddict_contradicting_declared_key_raises() -> None:
+    class Wrong(TypedDict):
+        year: str
+
+    year = Key("year", int)
+    matches = Rebulk().declare_keys(year).regex(r"\d{4}", name="year").matches("1984")
+    with pytest.raises(TypeError, match="contradicts declared key"):
+        matches.to(Wrong)
+
+
+def test_to_model_declared_key_list_element_checked() -> None:
+    @dataclass
+    class Good:
+        digit: list[int] = field(default_factory=list)
+
+    @dataclass
+    class Bad:
+        digit: list[str] = field(default_factory=list)
+
+    digit = Key("digit", int)
+    matches = Rebulk().declare_keys(digit).regex(r"\d", name="digit").matches("1 2 3")
+
+    assert matches.to(Good).digit == [1, 2, 3]  # element type agrees
+    with pytest.raises(TypeError, match="contradicts declared key"):
+        matches.to(Bad)
+
+
+def test_to_model_declared_key_optional_element_checked() -> None:
+    @dataclass
+    class Good:
+        year: int | None = None  # PEP 604 union (types.UnionType)
+
+    @dataclass
+    class Bad:
+        year: Optional[str] = None  # noqa: UP045  # legacy typing.Union form
+
+    year = Key("year", int)
+    matches = Rebulk().declare_keys(year).regex(r"\d{4}", name="year").matches("1984")
+
+    assert matches.to(Good).year == 1984
+    with pytest.raises(TypeError, match="contradicts declared key"):
+        matches.to(Bad)
+
+
+def test_to_model_declared_key_subclass_is_compatible() -> None:
+    @dataclass
+    class Release:
+        released: datetime
+
+    # date key, datetime field: related by subclassing, so no contradiction.
+    released = Key("released", date, formatter=lambda s: datetime.fromisoformat(s))
+    matches = Rebulk().declare_keys(released).regex(r"\S+", name="released").matches("2008-01-02T10:00:00")
+
+    assert matches.to(Release).released == datetime(2008, 1, 2, 10, 0, 0)
+
+
+def test_to_model_unresolvable_field_type_never_contradicts() -> None:
+    @dataclass
+    class Loose:
+        year: Any = None
+
+    year = Key("year", int)
+    matches = Rebulk().declare_keys(year).regex(r"\d{4}", name="year").matches("1984")
+
+    # An ``Any`` (or otherwise unresolvable) field type is always compatible.
+    assert matches.to(Loose).year == 1984
+
+
+def test_contradicts_bare_container_is_unresolved() -> None:
+    # A bare, unparameterized container carries no element type, so it never
+    # contradicts a declared scalar key (no spurious TypeError in to()).
+    for container in (list, tuple, set, frozenset, dict):
+        assert _contradicts(container, str) is False
+        assert _contradicts(container, int) is False
+    # A parameterized container is still checked against its element type.
+    assert _contradicts(list[int], str) is True
+    assert _contradicts(list[int], int) is False
+
+
+def test_to_model_disabled_rebulk_does_not_carry_declared_keys() -> None:
+    @dataclass
+    class Wrong:
+        year: str = "n/a"  # would contradict the int key if it were carried
+
+    year = Key("year", int)
+    rb = Rebulk(disabled=lambda context: True).declare_keys(year).regex(r"\d{4}", name="year")
+    matches = rb.matches("1984")
+
+    # Patterns never ran (disabled), so no declared keys are carried and the
+    # cross-check stays silent rather than rejecting a model with no values.
+    assert matches.declared_keys == {}
+    assert matches.to(Wrong) == Wrong()
+
+
+def test_to_model_field_without_declared_key_is_untouched() -> None:
+    # A model field with no matching declared key is never cross-checked.
+    year = Key("year", int)
+    matches = Rebulk().declare_keys(year).regex(r"\d{4}", key=year).string("Title", name="title").matches("Title 1999")
+
+    assert matches.to(Movie) == Movie(year=1999, title="Title")
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Contexte

Suite de #65 / #66 (typed `Key` + `declare_keys`). Le registre de clés déclarées typait la *récupération* (`matches[KEY]`, `matches.all(KEY)`) mais pas la *projection de sortie* : `matches.to(Model)` ignorait les `Key.value_type` déclarés. Cette PR ferme la boucle de typage jusqu'au bord de sortie.

Closes #67

## Changements

- **`Matches.declared_keys`** : le registre de clés déclarées du builder est désormais porté sur les `Matches` produits, fusionné depuis les rebulks enfants via le nouveau `Rebulk.effective_keys(context)` (le parent l'emporte ; cohérent avec `effective_patterns`/`effective_rules`, peuplé uniquement si le rebulk n'est pas désactivé).
- **Vérification croisée dans `Matches.to(Model)`** : un champ de dataclass/`TypedDict` dont le type (élément) contredit le `value_type` d'une clé déclarée de même nom lève `TypeError`, au lieu de produire silencieusement un résultat mal typé.
- Helpers `_element_type` / `_contradicts` : résolution de l'élément pour `list[X]`, `Optional[X]` / `X | None` (formes PEP 604 **et** `typing.Union`), tolérance des relations de sous-classe (clé `date` vs champ `datetime`), et traitement de `Any` / conteneurs nus / annotations non résolues comme compatibles.
- `to_dict()` est inchangé (la fonctionnalité reste opt-in via `declare_keys`).

## Tests / vérifications

- Nouveaux tests couvrant : contradiction scalaire/liste/optionnelle, sous-classe compatible, `Any`, conteneur nu, rebulk désactivé, registre porté sur `Matches`, fusion `effective_keys`, priorité parent.
- Section README + doctest.
- ✅ 221 tests sur backend `re` **et** `regex`, `mypy` strict, `ruff check`/`format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4Ryxr6Fc7sCERn6WChpqv