### PR TITLE
feat(key): opt-in debug check that match values match declared Key.value_type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,41 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
+  declared-keys-check:
+    # Dedicated signal: run the suite with the opt-in declared-key value_type
+    # contract check enabled, turning each declared Key.value_type into an
+    # actively-enforced contract (see debug.CHECK_DECLARED_KEYS / issue #68).
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        regex: [ "1", "0" ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: "3.14"
+          enable-cache: true
+
+      - name: Sync dependencies
+        run: uv sync --no-dev --group test
+
+      - name: Sync regex backend
+        run: uv sync --no-dev --group test --extra native
+        if: ${{ matrix.regex == '1' }}
+
+      - name: Tests (declared-key contract check on)
+        run: uv run --no-sync pytest
+        env:
+          REBULK_REGEX_ENABLED: ${{ matrix.regex }}
+          REBULK_CHECK_DECLARED_KEYS: "1"
+
   pre-commit:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,9 @@ uv run pre-commit run --all-files
 
 # Run the suite against the `regex` backend (see remodule.py)
 REBULK_REGEX_ENABLED=1 uv run pytest
+
+# Run the suite with the declared-key value_type contract check on (see debug.py)
+REBULK_CHECK_DECLARED_KEYS=1 uv run pytest
 ```
 
 CI runs the full matrix twice — with `REBULK_REGEX_ENABLED` set to `0` and `1` — so changes touching pattern matching must pass under both the stdlib `re` and the `regex` backend.

--- a/README.md
+++ b/README.md
@@ -659,6 +659,27 @@ TypeError: Wrong field 'season' typed <class 'str'> contradicts declared key 'se
 
 ```
 
+The declared `value_type` only describes the *output*; the actual conversion is
+the per-pattern formatter, which `declare_keys` lets a pattern override. An
+opt-in contract check verifies the two agree: when enabled, `matches` asserts
+that every named match value is an instance of the declared key's `value_type`,
+raising `TypeError` on a mismatch (a `None` value, a `value=`-mapped literal that
+never went through the converter, are exempt). It is **off by default** (zero
+cost in production) — turn it on in development or CI to catch a formatter
+override that does not produce the declared type:
+
+```python
+>>> from rebulk import debug
+>>> debug.CHECK_DECLARED_KEYS = True   # or env REBULK_CHECK_DECLARED_KEYS=1
+>>> bad = Rebulk().declare_keys(season).regex(r'S(?P<season>\d+)', formatter={'season': str}, children=True)
+>>> bad.matches("S03")
+Traceback (most recent call last):
+    ...
+TypeError: match 'season' value '03' of type 'str' does not match declared key 'season' value_type <class 'int'>
+>>> debug.CHECK_DECLARED_KEYS = False
+
+```
+
 Markers
 =======
 

--- a/rebulk/debug.py
+++ b/rebulk/debug.py
@@ -26,6 +26,20 @@ DEBUG: bool = False
 LOG_LEVEL: int = logging.DEBUG
 
 
+def _truthy_env(name: str) -> bool:
+    """True when environment variable ``name`` holds an affirmative value."""
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+# Optional, opt-in contract check (off by default, no cost in production): when
+# enabled, ``Rebulk.matches`` asserts that every named match value produced by a
+# pattern matches the ``value_type`` of the same-named declared ``Key`` (see
+# ``declare_keys``), turning the declared type into an enforced contract. Flip it
+# on from the environment (``REBULK_CHECK_DECLARED_KEYS=1``) — e.g. in CI or for a
+# downstream corpus run — or by setting this flag directly.
+CHECK_DECLARED_KEYS: bool = _truthy_env("REBULK_CHECK_DECLARED_KEYS")
+
+
 class Frame(namedtuple("Frame", ["lineno", "package", "name", "filename"])):
     """
     Stack frame representation.

--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -910,6 +910,42 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
                 kwargs[name] = values[0]
         return model(**kwargs)
 
+    def check_declared_keys(self) -> None:
+        """
+        Assert each named match value matches its declared ``Key.value_type``.
+
+        For every match whose name has a declared :class:`~rebulk.key.Key` (see
+        :meth:`~rebulk.builder.PatternFactory.declare_keys`), check that the
+        formatted value is an instance of the key's ``value_type``, raising
+        ``TypeError`` on a mismatch. This turns the declared output type into an
+        enforced contract, catching a per-pattern ``formatter`` override that does
+        not actually produce the declared type.
+
+        It is meant to run in development / CI (it does nothing useful unless keys
+        are declared); :class:`~rebulk.rebulk.Rebulk` calls it from ``matches``
+        only when :data:`rebulk.debug.CHECK_DECLARED_KEYS` is enabled.
+
+        Three escape hatches keep it free of false positives:
+
+        * a ``None`` value (an unmatched / cleared match) is skipped;
+        * a ``value=``-mapped match (a hardcoded literal that never went through
+          the converter) is skipped — its value is not a ``str -> value_type``
+          conversion;
+        * each match is checked on its own scalar value, so a name bound to
+          several matches (``children``) is validated element by element.
+        """
+        for match in self:
+            key = self.declared_keys.get(match.name) if match.name else None
+            if key is None or match.has_literal_value:
+                continue
+            value = match.value
+            if value is None or isinstance(value, key.value_type):
+                continue
+            raise TypeError(
+                f"match {match.name!r} value {value!r} of type {type(value).__name__!r} "
+                f"does not match declared key {key.name!r} value_type {key.value_type!r}"
+            )
+
     @overload
     def __setitem__(self, index: int, match: Match) -> None: ...
 
@@ -1052,6 +1088,17 @@ class Match:
         :rtype:
         """
         self._value = value
+
+    @property
+    def has_literal_value(self) -> bool:
+        """
+        True when :attr:`value` returns a hardcoded literal (set via ``value=``)
+        rather than a formatter / raw-text result.
+
+        Mirrors the truthiness test the :attr:`value` getter uses, so it reflects
+        exactly when ``value`` short-circuits to the stored literal.
+        """
+        return bool(self._value)
 
     @property
     def names(self) -> set[str | None]:

--- a/rebulk/rebulk.py
+++ b/rebulk/rebulk.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, cast
 
+from . import debug
 from .builder import Builder
 from .match import Matches
 from .processors import ConflictSolver, PrivateRemover
@@ -128,6 +129,12 @@ class Rebulk(Builder):
             matches.declared_keys = self.effective_keys(context)
 
         self._matches_patterns(matches, context)
+
+        # Validate formatter output against declared Key.value_type *before* rules
+        # run: the contract is about the value a pattern's formatter produced, not
+        # about matches that a rule later renames/relocates onto a declared name.
+        if debug.CHECK_DECLARED_KEYS:
+            matches.check_declared_keys()
 
         self._execute_rules(matches, context)
 

--- a/rebulk/test/test_key.py
+++ b/rebulk/test/test_key.py
@@ -8,17 +8,17 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from datetime import date
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import pytest
 
+from .. import debug
 from ..key import Key
+from ..match import Match, Matches
 from ..rebulk import Rebulk
 
 if TYPE_CHECKING:
     from typing_extensions import assert_type
-
-    from ..match import Match
 
 
 def test_key_scalar_retrieval() -> None:
@@ -176,9 +176,12 @@ def test_declare_keys_explicit_formatter_overrides_registry() -> None:
     assert matches.all(episode) == [4]
 
 
-def test_declare_keys_bare_callable_formatter_wins() -> None:
+def test_declare_keys_bare_callable_formatter_wins(monkeypatch: pytest.MonkeyPatch) -> None:
     # A single bare-callable formatter is the pattern's explicit choice and must
     # win over the registry converter (variance preserved, even without a dict).
+    # This deliberately produces a str for an int key, so force the contract
+    # check off (it stays runnable under REBULK_CHECK_DECLARED_KEYS=1).
+    monkeypatch.setattr(debug, "CHECK_DECLARED_KEYS", False)
     year = Key("year", int)
     bulk = Rebulk().declare_keys(year).regex(r"\d{4}", name="year", formatter=lambda s: f"Y{s}")
     matches = bulk.matches("born in 1984")
@@ -277,6 +280,117 @@ def test_effective_keys_parent_wins_over_child() -> None:
     parent = Rebulk().declare_keys(parent_key).rebulk(Rebulk().declare_keys(child_key))
 
     assert parent.effective_keys() == {"dup": parent_key}
+
+
+@pytest.fixture
+def check_declared_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enable the opt-in declared-key value_type contract check for a test."""
+    monkeypatch.setattr(debug, "CHECK_DECLARED_KEYS", True)
+
+
+def test_truthy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for raw, expected in [("1", True), ("true", True), ("YES", True), (" on ", True), ("0", False), ("", False)]:
+        monkeypatch.setenv("REBULK_TEST_FLAG", raw)
+        assert debug._truthy_env("REBULK_TEST_FLAG") is expected
+    monkeypatch.delenv("REBULK_TEST_FLAG", raising=False)
+    assert debug._truthy_env("REBULK_TEST_FLAG") is False
+
+
+def test_check_declared_keys_disabled_is_silent(monkeypatch: pytest.MonkeyPatch) -> None:
+    # When the check is off, a contract violation is silent (no behaviour change).
+    monkeypatch.setattr(debug, "CHECK_DECLARED_KEYS", False)
+    season = Key("season", int)
+    bulk = Rebulk().declare_keys(season).regex(r"S(?P<season>\d+)", formatter={"season": str}, children=True)
+    matches = bulk.matches("S03")
+
+    # str value despite the int declaration: the check is off, so it is not flagged.
+    assert matches[0].value == "03"
+
+
+def test_check_declared_keys_passes_on_matching_type(check_declared_keys: None) -> None:
+    season = Key("season", int)
+    episode = Key("episode", int)
+    bulk = Rebulk().declare_keys(season, episode).regex(r"S(?P<season>\d+)E(?P<episode>\d+)", children=True)
+
+    # Inherited int converters produce ints: the contract holds, no raise.
+    matches = bulk.matches("S03E07")
+    assert matches[season] == 3
+    assert matches[episode] == 7
+
+
+def test_check_declared_keys_raises_on_formatter_override_mismatch(check_declared_keys: None) -> None:
+    season = Key("season", int)
+    # A per-pattern override returns str while the key declares int.
+    bulk = Rebulk().declare_keys(season).regex(r"S(?P<season>\d+)", formatter={"season": str}, children=True)
+
+    with pytest.raises(TypeError, match=r"declared key 'season' value_type"):
+        bulk.matches("S03")
+
+
+def test_check_declared_keys_validates_each_match() -> None:
+    # A name bound to several matches is validated value by value: the first
+    # converts to int (ok), the second to str (mismatch) -> raise.
+    episode = Key("episode", int)
+    matches = Matches()
+    matches.declared_keys = {"episode": episode}
+    matches.append(Match(0, 1, name="episode", input_string="7 8", formatter=int))
+    matches.append(Match(2, 3, name="episode", input_string="7 8", formatter=str))
+
+    with pytest.raises(TypeError, match=r"declared key 'episode' value_type"):
+        matches.check_declared_keys()
+
+
+def test_check_declared_keys_skips_none_value() -> None:
+    # A formatted value of None (e.g. a converter that returns None) is exempt
+    # rather than flagged against the declared scalar type.
+    year = Key("year", int)
+    matches = Matches()
+    matches.declared_keys = {"year": year}
+    matches.append(Match(0, 4, name="year", input_string="1984", formatter=lambda _raw: None))
+
+    matches.check_declared_keys()  # no raise
+
+
+def test_check_declared_keys_skips_value_mapped_literal() -> None:
+    # A value=-mapped literal never goes through the converter; it is exempt
+    # even when its type differs from the declared value_type.
+    season = Key("season", int)
+    matches = Matches()
+    matches.declared_keys = {"season": season}
+    matches.append(Match(0, 7, value="literal", name="season", input_string="literal"))
+
+    matches.check_declared_keys()  # no raise
+
+
+def test_check_declared_keys_runs_before_rules(check_declared_keys: None) -> None:
+    from ..rules import RenameMatch, Rule
+
+    season = Key("season", int)
+
+    class RenameLabelToSeason(Rule):
+        consequence = RenameMatch("season")
+
+        def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+            return matches.named("label")
+
+    bulk = Rebulk().declare_keys(season).regex(r"(?P<label>[a-z]+)", children=True).rules(RenameLabelToSeason)
+    matches = bulk.matches("hello")
+
+    # A rule renames a str match onto 'season' (declared int). The check runs
+    # before rules, so this legitimate rule-driven rename is not flagged.
+    assert matches[0].name == "season"
+    assert matches[0].value == "hello"
+
+
+def test_check_declared_keys_unnamed_and_undeclared_are_ignored() -> None:
+    season = Key("season", int)
+    matches = Matches()
+    matches.declared_keys = {"season": season}
+    # An unnamed match and a match with an undeclared name are both skipped.
+    matches.append(Match(0, 3, value="x", input_string="x y z"))
+    matches.append(Match(4, 5, name="other", input_string="x y z", formatter=str))
+
+    matches.check_declared_keys()  # no raise
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Contexte

Suite de #65 (caveat promu en ticket dédié). Un `Key.value_type` déclare le type de *sortie*, mais la conversion réelle est le formatter par-pattern — que `declare_keys` permet d'overrider. Rien ne vérifiait que les deux concordent : un override produisant un mauvais type rendait le type déclaré mensonger en silence.

Closes #68

## Changements

- **`debug.CHECK_DECLARED_KEYS`** : flag opt-in (off par défaut, coût nul en production), activable via `REBULK_CHECK_DECLARED_KEYS=1` ou en réglant le flag.
- **`Matches.check_declared_keys()`** : quand le flag est actif, `Rebulk.matches()` vérifie que chaque valeur de match nommé est une instance du `value_type` de la clé déclarée de même nom, et lève `TypeError` sur incohérence.
- **Échappatoires** (zéro faux positif) : valeurs `None`, littéraux `value=` (jamais passés par le converter), validation par-match pour les `children`.
- La **suite entière tourne avec le check activé** (les 2 tests de violation volontaire forcent le flag off localement) ; un **job CI dédié** `declared-keys-check` l'exécute sur les deux backends `regex`, faisant de chaque `value_type` un contrat activement vérifié.
- Documentation README + CLAUDE.md.

## Tests / vérifications

- Tests couvrant : type conforme (pass), override de formatter incohérent (raise), validation par-match, échappatoires `None` / littéral `value=` / non-déclaré / non-nommé, parsing de l'env var, comportement silencieux quand désactivé.
- ✅ 229 tests sur backend `re` **et** `regex`, **avec et sans** le check activé ; `mypy` strict ; `ruff check`/`format` ; doctests README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4Ryxr6Fc7sCERn6WChpqv