### PR TITLE
feat(key): add Rebulk.check_keys() to flag declared keys no pattern produces

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,27 @@ TypeError: match 'season' value '03' of type 'str' does not match declared key '
 
 ```
 
+A declared key binds by *name*, so a typo or a name kept after its pattern was
+removed silently no-ops. `check_keys` guards against that: it returns the
+declared key names that no built pattern can produce (its `name`, regex group
+names, and declared `properties`, across the rebulk and its children). The full
+pattern set is considered regardless of `disabled`, so the result is
+deterministic — assert it in a test so a typo fails fast instead of doing
+nothing. A name produced only by a rule (e.g. `RenameMatch`) or dynamically by a
+functional pattern is not statically detectable; pass such names — or any other
+intentionally pattern-less key — to `allowed_unused` (a single name or an
+iterable).
+
+```python
+>>> rb = Rebulk().declare_keys(Key('season', int), Key('seson', int)) \
+...        .regex(r'S(?P<season>\d+)', children=True)
+>>> rb.check_keys()
+['seson']
+>>> rb.check_keys(allowed_unused=['seson'])
+[]
+
+```
+
 Markers
 =======
 

--- a/rebulk/rebulk.py
+++ b/rebulk/rebulk.py
@@ -10,20 +10,44 @@ from typing import TYPE_CHECKING, Any, cast
 
 from . import debug
 from .builder import Builder
+from .chain import Chain
 from .match import Matches
+from .pattern import Pattern, RePattern
 from .processors import ConflictSolver, PrivateRemover
 from .rules import CustomRule, Rules
 from .utils import extend_safe
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     from typing_extensions import Self
 
     from .key import Key
-    from .pattern import Pattern
 
 log = getLogger(__name__).log
+
+
+def _producible_names(pattern: Pattern) -> set[str]:
+    """
+    Names a pattern can emit: any name it declares via ``properties``, its own
+    ``name``, every regex group name, and — for a :class:`~rebulk.chain.Chain` —
+    the names of its parts. Private/marker names are included so a key targeting
+    one is not flagged as unused.
+
+    This mirrors the name extraction in :class:`~rebulk.introspector.PatternDescription`
+    but is intentionally *inclusive* (it keeps private/marker names), whereas
+    introspection filters them out for its public-properties view.
+    """
+    names: set[str] = set(pattern.properties)
+    if pattern.name:
+        names.add(pattern.name)
+    if isinstance(pattern, RePattern):
+        for compiled in pattern.patterns:
+            names.update(compiled.groupindex)
+    elif isinstance(pattern, Chain):
+        for part in pattern.parts:
+            names |= _producible_names(part.pattern)
+    return names
 
 
 class Rebulk(Builder):
@@ -172,6 +196,44 @@ class Rebulk(Builder):
                 for name, key in rebulk._keys.items():
                     keys.setdefault(name, key)
         return keys
+
+    def check_keys(self, *, allowed_unused: str | Iterable[str] = ()) -> list[str]:
+        """
+        Return declared key names that no built pattern can produce (typo guard).
+
+        A declared :class:`~rebulk.key.Key` binds its converter/type to a match
+        name (see :meth:`~rebulk.builder.PatternFactory.declare_keys`); a typo or
+        a name kept after its pattern was removed silently no-ops. This compares
+        every declared key name against the names every pattern *can* emit — its
+        ``name`` plus regex group names, across this rebulk and its children —
+        and returns the declared names matched by none, sorted.
+
+        The full pattern set is considered regardless of ``disabled`` (a key
+        whose patterns are all disabled by config is still legitimately declared),
+        so the result is deterministic and config-independent: ideal to assert in
+        a test (``assert not rb.check_keys()``) so a typo fails fast in CI rather
+        than silently doing nothing.
+
+        Only names a *pattern* can emit are considered (its ``name``, regex group
+        names, and declared ``properties``). A name produced solely by a rule
+        (e.g. ``RenameMatch``/``AppendMatch``) or dynamically by a functional
+        pattern is not detectable statically; pass such names — and any other
+        intentionally pattern-less key — via ``allowed_unused`` (a single name or
+        an iterable of names) to exempt them.
+        """
+        declared: dict[str, Key[Any]] = dict(self._keys)
+        patterns: list[Pattern] = list(self._patterns)
+        for rebulk in self._rebulks:
+            for name, key in rebulk._keys.items():
+                declared.setdefault(name, key)
+            patterns.extend(rebulk._patterns)
+        if not declared:
+            return []
+        produced: set[str] = set()
+        for pattern in patterns:
+            produced |= _producible_names(pattern)
+        allowed = {allowed_unused} if isinstance(allowed_unused, str) else set(allowed_unused)
+        return sorted(name for name in declared if name not in produced and name not in allowed)
 
     def _execute_rules(self, matches: Matches, context: dict[str, Any]) -> None:
         """

--- a/rebulk/test/test_key.py
+++ b/rebulk/test/test_key.py
@@ -393,6 +393,117 @@ def test_check_declared_keys_unnamed_and_undeclared_are_ignored() -> None:
     matches.check_declared_keys()  # no raise
 
 
+def test_check_keys_flags_typo() -> None:
+    season = Key("season", int)
+    typo = Key("seson", int)  # never produced by the pattern below
+    rb = Rebulk().declare_keys(season, typo).regex(r"S(?P<season>\d+)", children=True)
+
+    assert rb.check_keys() == ["seson"]
+
+
+def test_check_keys_clean_when_all_match() -> None:
+    season = Key("season", int)
+    episode = Key("episode", int)
+    rb = Rebulk().declare_keys(season, episode).regex(r"S(?P<season>\d+)E(?P<episode>\d+)", children=True)
+
+    assert rb.check_keys() == []
+
+
+def test_check_keys_matches_pattern_name_not_only_groups() -> None:
+    # A key can target a pattern's name (string/functional/named regex), not only
+    # a regex group name.
+    year = Key("year", int)
+    rb = Rebulk().declare_keys(year).regex(r"\d{4}", name="year")
+
+    assert rb.check_keys() == []
+
+
+def test_check_keys_no_declared_keys_is_empty() -> None:
+    assert Rebulk().regex(r"\d{4}", name="year").check_keys() == []
+
+
+def test_check_keys_allowlist_exempts_intentional_unused() -> None:
+    season = Key("season", int)
+    extra = Key("extra", str)  # intentionally declared without a producing pattern
+    rb = Rebulk().declare_keys(season, extra).regex(r"S(?P<season>\d+)", children=True)
+
+    assert rb.check_keys() == ["extra"]
+    assert rb.check_keys(allowed_unused=["extra"]) == []
+    # A bare string is treated as a single name (not iterated char by char).
+    assert rb.check_keys(allowed_unused="extra") == []
+
+
+def test_check_keys_honors_pattern_declared_properties() -> None:
+    # A pattern (e.g. functional) that emits a name dynamically can declare it via
+    # `properties`; check_keys honors that declaration.
+    season = Key("season", int)
+    rb = Rebulk().declare_keys(season).functional(lambda string: None, properties={"season": [None]})
+
+    assert rb.check_keys() == []
+
+
+def test_check_keys_rule_produced_name_needs_allowlist() -> None:
+    # A name produced only by a rule (not a pattern) is not statically detectable,
+    # so it is reported unless allowlisted — documents the known limitation.
+    from ..rules import RenameMatch, Rule
+
+    year = Key("year", int)
+
+    class RenameRawToYear(Rule):
+        consequence = RenameMatch("year")
+
+        def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+            return matches.named("raw_year")
+
+    rb = Rebulk().declare_keys(year).regex(r"(?P<raw_year>\d{4})", children=True).rules(RenameRawToYear)
+
+    assert rb.check_keys() == ["year"]
+    assert rb.check_keys(allowed_unused="year") == []
+
+
+def test_check_keys_considers_children_rebulks() -> None:
+    season = Key("season", int)
+    episode = Key("episode", int)
+    typo = Key("epsiode", int)
+
+    child = Rebulk().regex(r"E(?P<episode>\d+)", children=True)
+    parent = Rebulk().declare_keys(season, episode, typo).regex(r"S(?P<season>\d+)", children=True).rebulk(child)
+
+    # 'episode' is produced by the child; only the typo 'epsiode' is unused.
+    assert parent.check_keys() == ["epsiode"]
+
+
+def test_check_keys_considers_disabled_patterns_full_set() -> None:
+    # A key whose only producing pattern lives in a disabled child rebulk is NOT
+    # flagged: the typo guard considers the full built pattern set, not the
+    # config-gated effective one.
+    season = Key("season", int)
+    episode = Key("episode", int)
+
+    disabled_child = Rebulk(disabled=lambda context: True).regex(r"E(?P<episode>\d+)", children=True)
+    parent = Rebulk().declare_keys(season, episode).regex(r"S(?P<season>\d+)", children=True).rebulk(disabled_child)
+
+    assert parent.check_keys() == []
+
+
+def test_check_keys_in_chain() -> None:
+    episode = Key("episode", int)
+    version = Key("version", int)
+    typo = Key("verison", int)
+
+    rb = (
+        Rebulk()
+        .declare_keys(episode, version, typo)
+        .defaults(children=True)
+        .chain()
+        .regex(r"e(?P<episode>\d{1,4})")
+        .regex(r"v(?P<version>\d+)")
+        .close()
+    )
+
+    assert rb.check_keys() == ["verison"]
+
+
 if TYPE_CHECKING:
 
     def _reveal_types() -> None:


### PR DESCRIPTION
## Contexte

Suite de #65. `declare_keys` lie un converter/type à un nom de match ; une faute de frappe ou un nom resté après suppression de son pattern fait un no-op silencieux — rien ne le signale.

Closes #69

## Changements

- **`Rebulk.check_keys(*, allowed_unused=())`** : compare chaque nom de clé déclarée à l'ensemble des noms que **chaque pattern construit peut émettre** (son `name` + les noms de groupes regex, à travers le rebulk et ses enfants), et renvoie trié les noms qu'aucun pattern ne produit.
- L'**ensemble complet** des patterns est considéré (indépendamment de `disabled(context)`) → résultat déterministe et indépendant de la config : `assert not rb.check_keys()` dans un test fait échouer une faute de frappe immédiatement en CI, plutôt qu'un no-op silencieux.
- **`allowed_unused`** : allowlist pour les noms déclarés intentionnellement sans pattern producteur (évite les faux positifs).
- Helper `_producible_names` inclusif (groupes privés inclus, récursion dans les `Chain`).

## Tests / vérifications

- Tests couvrant : faute de frappe, cas propre, nom de pattern (non-groupe), allowlist, rebulks enfants, ensemble complet malgré `disabled`, chaîne, aucune clé déclarée.
- README mis à jour (doctest).
- ✅ 238 tests sur backend `re` **et** `regex` ; `mypy` strict ; `ruff check`/`format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4Ryxr6Fc7sCERn6WChpqv