### PR TITLE
feat(key)!: accept key= as Key | Sequence[Key], fold in keys=

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,15 +557,16 @@ datetime.date(2008, 1, 2)
 ```
 
 A single `key=` wires one match name and formatter. For a `children=True`
-pattern that exposes several named groups, pass `keys=` instead: each key's
-converter is registered under its name as a per-name formatter, and an explicit
-per-pattern `formatter` entry still overrides it.
+pattern that exposes several named groups, pass a sequence of keys to the same
+`key=` parameter instead: each key's converter is registered under its name as a
+per-name formatter, and an explicit per-pattern `formatter` entry still
+overrides it.
 
 ```python
 >>> season = Key("season", int)
 >>> episode = Key("episode", int)
 >>> matches = Rebulk().regex(r'S(?P<season>\d+)E(?P<episode>\d+)',
-...                          keys=[season, episode], children=True) \
+...                          key=[season, episode], children=True) \
 ...                   .matches("Show.S03E07.mkv")
 >>> matches[season]
 3

--- a/rebulk/builder.py
+++ b/rebulk/builder.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 from .chain import Chain, ChainPart
 from .formatters import default_formatter
+from .key import Key
 from .loose import set_defaults
 from .pattern import FunctionalPattern, Pattern, RePattern, StringPattern
 
@@ -21,49 +22,45 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
-    from .key import Key
-
 log = getLogger(__name__).log
 
 _P = TypeVar("_P", bound=Pattern)
 
 
-def _apply_key(key: Key[Any] | None, kwargs: dict[str, Any]) -> dict[str, Any]:
-    """
-    Inject a typed :class:`~rebulk.key.Key`'s name and converter (its explicit
-    ``formatter`` or its ``value_type``) into pattern kwargs, without overriding
-    explicit values.
-    """
-    if key is not None:
-        kwargs.setdefault("name", key.name)
-        kwargs.setdefault("formatter", key.converter)
-    return kwargs
+def _apply_key(key: Key[Any] | Sequence[Key[Any]] | None, kwargs: dict[str, Any]) -> dict[str, Any]:
+    r"""
+    Inject one or several typed :class:`~rebulk.key.Key` into pattern kwargs,
+    without overriding explicit values.
 
-
-def _apply_keys(keys: Sequence[Key[Any]] | None, kwargs: dict[str, Any]) -> dict[str, Any]:
-    """
-    Inject several typed :class:`~rebulk.key.Key` as a per-name ``formatter``
-    dict, composing with ``children=True`` patterns that expose several named
-    groups (e.g. ``(?P<season>\\d+)(?P<episode>\\d+)``).
-
-    Each key's converter is registered under its ``name``; explicit per-name
+    A single ``Key`` sets the match ``name`` and the ``formatter`` (its explicit
+    ``formatter`` or its ``value_type``). A sequence of keys instead builds a
+    per-name ``formatter`` dict, composing with ``children=True`` patterns that
+    expose several named groups (e.g. ``(?P<season>\d+)(?P<episode>\d+)``): each
+    key's converter is registered under its ``name``, and explicit per-name
     entries already present in ``formatter`` are preserved (a per-pattern
     formatter still wins over the key's converter).
     """
-    if keys:
-        formatter = kwargs.get("formatter")
-        if formatter is None:
-            formatter = {}
-        elif isinstance(formatter, dict):
-            formatter = dict(formatter)  # copy: never mutate the caller's dict
-        else:
-            raise TypeError(
-                "keys= builds a per-name formatter dict and cannot be combined with a single "
-                "formatter callable; pass a per-name formatter dict or drop the explicit formatter"
-            )
-        for key in keys:
-            formatter.setdefault(key.name, key.converter)
-        kwargs["formatter"] = formatter
+    if key is None:
+        return kwargs
+    if isinstance(key, Key):
+        kwargs.setdefault("name", key.name)
+        kwargs.setdefault("formatter", key.converter)
+        return kwargs
+    if not key:
+        return kwargs
+    formatter = kwargs.get("formatter")
+    if formatter is None:
+        formatter = {}
+    elif isinstance(formatter, dict):
+        formatter = dict(formatter)  # copy: never mutate the caller's dict
+    else:
+        raise TypeError(
+            "a sequence of keys builds a per-name formatter dict and cannot be combined with a "
+            "single formatter callable; pass a per-name formatter dict or drop the explicit formatter"
+        )
+    for single_key in key:
+        formatter.setdefault(single_key.name, single_key.converter)
+    kwargs["formatter"] = formatter
     return kwargs
 
 
@@ -230,44 +227,41 @@ class Builder(PatternFactory, metaclass=ABCMeta):
         :return:
         """
 
-    def regex(
-        self, *pattern: Any, key: Key[Any] | None = None, keys: Sequence[Key[Any]] | None = None, **kwargs: Any
-    ) -> Self:
+    def regex(self, *pattern: Any, key: Key[Any] | Sequence[Key[Any]] | None = None, **kwargs: Any) -> Self:
         """
         Add re pattern
 
-        :param key: optional typed key wiring up the match name and value type.
-        :param keys: optional typed keys wiring up a per-name formatter dict, for
-            ``children=True`` patterns exposing several named groups.
+        :param key: optional typed key(s). A single :class:`~rebulk.key.Key`
+            wires up the match name and value type; a sequence of keys wires up a
+            per-name formatter dict, for ``children=True`` patterns exposing
+            several named groups.
         :return: self
         """
-        return self.pattern(self.build_re(*pattern, **_apply_keys(keys, _apply_key(key, kwargs))))
+        return self.pattern(self.build_re(*pattern, **_apply_key(key, kwargs)))
 
-    def string(
-        self, *pattern: Any, key: Key[Any] | None = None, keys: Sequence[Key[Any]] | None = None, **kwargs: Any
-    ) -> Self:
+    def string(self, *pattern: Any, key: Key[Any] | Sequence[Key[Any]] | None = None, **kwargs: Any) -> Self:
         """
         Add string pattern
 
-        :param key: optional typed key wiring up the match name and value type.
-        :param keys: optional typed keys wiring up a per-name formatter dict, for
-            ``children=True`` patterns exposing several named groups.
+        :param key: optional typed key(s). A single :class:`~rebulk.key.Key`
+            wires up the match name and value type; a sequence of keys wires up a
+            per-name formatter dict, for ``children=True`` patterns exposing
+            several named groups.
         :return: self
         """
-        return self.pattern(self.build_string(*pattern, **_apply_keys(keys, _apply_key(key, kwargs))))
+        return self.pattern(self.build_string(*pattern, **_apply_key(key, kwargs)))
 
-    def functional(
-        self, *pattern: Any, key: Key[Any] | None = None, keys: Sequence[Key[Any]] | None = None, **kwargs: Any
-    ) -> Self:
+    def functional(self, *pattern: Any, key: Key[Any] | Sequence[Key[Any]] | None = None, **kwargs: Any) -> Self:
         """
         Add functional pattern
 
-        :param key: optional typed key wiring up the match name and value type.
-        :param keys: optional typed keys wiring up a per-name formatter dict, for
-            ``children=True`` patterns exposing several named groups.
+        :param key: optional typed key(s). A single :class:`~rebulk.key.Key`
+            wires up the match name and value type; a sequence of keys wires up a
+            per-name formatter dict, for ``children=True`` patterns exposing
+            several named groups.
         :return: self
         """
-        return self.pattern(self.build_functional(*pattern, **_apply_keys(keys, _apply_key(key, kwargs))))
+        return self.pattern(self.build_functional(*pattern, **_apply_key(key, kwargs)))
 
     def chain(self, **kwargs: Any) -> ChainBuilder:
         """
@@ -310,29 +304,23 @@ class ChainBuilder(PatternFactory):
         self._chain.parts.append(part)
         return part
 
-    def regex(
-        self, *pattern: Any, key: Key[Any] | None = None, keys: Sequence[Key[Any]] | None = None, **kwargs: Any
-    ) -> ChainPart:
+    def regex(self, *pattern: Any, key: Key[Any] | Sequence[Key[Any]] | None = None, **kwargs: Any) -> ChainPart:
         """
         Add a re pattern to the chain.
         """
-        return self._add(self.build_re(*pattern, **_apply_keys(keys, _apply_key(key, kwargs))))
+        return self._add(self.build_re(*pattern, **_apply_key(key, kwargs)))
 
-    def string(
-        self, *pattern: Any, key: Key[Any] | None = None, keys: Sequence[Key[Any]] | None = None, **kwargs: Any
-    ) -> ChainPart:
+    def string(self, *pattern: Any, key: Key[Any] | Sequence[Key[Any]] | None = None, **kwargs: Any) -> ChainPart:
         """
         Add a string pattern to the chain.
         """
-        return self._add(self.build_string(*pattern, **_apply_keys(keys, _apply_key(key, kwargs))))
+        return self._add(self.build_string(*pattern, **_apply_key(key, kwargs)))
 
-    def functional(
-        self, *pattern: Any, key: Key[Any] | None = None, keys: Sequence[Key[Any]] | None = None, **kwargs: Any
-    ) -> ChainPart:
+    def functional(self, *pattern: Any, key: Key[Any] | Sequence[Key[Any]] | None = None, **kwargs: Any) -> ChainPart:
         """
         Add a functional pattern to the chain.
         """
-        return self._add(self.build_functional(*pattern, **_apply_keys(keys, _apply_key(key, kwargs))))
+        return self._add(self.build_functional(*pattern, **_apply_key(key, kwargs)))
 
     def chain(self, **kwargs: Any) -> ChainBuilder:
         """

--- a/rebulk/test/test_key.py
+++ b/rebulk/test/test_key.py
@@ -83,7 +83,7 @@ def test_keys_children_per_name_formatter() -> None:
     season = Key("season", int)
     episode = Key("episode", int)
 
-    bulk = Rebulk().regex(r"S(?P<season>\d+)E(?P<episode>\d+)", keys=[season, episode], children=True)
+    bulk = Rebulk().regex(r"S(?P<season>\d+)E(?P<episode>\d+)", key=[season, episode], children=True)
     matches = bulk.matches("Show.S03E07.mkv")
 
     assert matches[season] == 3
@@ -96,7 +96,7 @@ def test_keys_multiple_children_values() -> None:
 
     bulk = Rebulk().regex(
         r"S(?P<season>\d+)(?:E(?P<episode>\d+))+",
-        keys=[season, episode],
+        key=[season, episode],
         children=True,
     )
     matches = bulk.matches("Show.S03E07.mkv")
@@ -113,7 +113,7 @@ def test_keys_preserve_explicit_per_name_formatter() -> None:
     # the key would apply plain str, the override upper-cases instead.
     bulk = Rebulk().regex(
         r"S(?P<season>\d+)E(?P<episode>\w+)",
-        keys=[season, episode],
+        key=[season, episode],
         formatter={"episode": str.upper},
         children=True,
     )
@@ -127,12 +127,19 @@ def test_keys_rejects_single_formatter_callable() -> None:
     season = Key("season", int)
 
     with pytest.raises(TypeError, match=r"per-name formatter"):
-        Rebulk().regex(r"(?P<season>\d+)", keys=[season], formatter=int, children=True)
+        Rebulk().regex(r"(?P<season>\d+)", key=[season], formatter=int, children=True)
 
 
 def test_keys_none_is_noop() -> None:
     year = Key("year", int)
-    matches = Rebulk().regex(r"\d{4}", key=year, keys=None).matches("born in 1984")
+    matches = Rebulk().regex(r"\d{4}", key=None).regex(r"\d{4}", key=year).matches("born in 1984")
+
+    assert matches[year] == 1984
+
+
+def test_keys_empty_sequence_is_noop() -> None:
+    year = Key("year", int)
+    matches = Rebulk().regex(r"\d{4}", key=[]).regex(r"\d{4}", key=year).matches("born in 1984")
 
     assert matches[year] == 1984
 
@@ -142,7 +149,7 @@ def test_declare_keys_inherited_per_name_formatter() -> None:
     episode = Key("episode", int)
 
     bulk = Rebulk().declare_keys(season, episode)
-    # No keys=/formatter= on the pattern: the converters are inherited from the registry.
+    # No key=/formatter= on the pattern: the converters are inherited from the registry.
     bulk.regex(r"S(?P<season>\d+)E(?P<episode>\d+)", children=True)
     matches = bulk.matches("Show.S03E07.mkv")
 
@@ -204,9 +211,9 @@ def test_keys_does_not_mutate_caller_formatter_dict() -> None:
     season = Key("season", int)
     episode = Key("episode", int)
     shared = {"episode": str.upper}
-    Rebulk().regex(r"S(?P<season>\d+)E(?P<episode>\w+)", keys=[season, episode], formatter=shared, children=True)
+    Rebulk().regex(r"S(?P<season>\d+)E(?P<episode>\w+)", key=[season, episode], formatter=shared, children=True)
 
-    # keys= must not leak the season converter into the caller's dict.
+    # key= must not leak the season converter into the caller's dict.
     assert shared == {"episode": str.upper}
 
 


### PR DESCRIPTION
## Context

Follow-up to #65 / #66. Builder methods exposed two related typed-key entry points — `key=` (single `Key`) and `keys=` (sequence). This unifies them into a single `key=` parameter.

## Changes

- `key=` now accepts `Key | Sequence[Key]`:
  - a single `Key` keeps the current name + formatter wiring,
  - a sequence builds the per-name `formatter` dict for `children=True` patterns (the former `keys=` behaviour), preserving explicit per-name entries and never mutating the caller's dict.
- Merged `_apply_key` / `_apply_keys` into one helper; dropped the `keys=` parameter from the `regex` / `string` / `functional` methods of both `Builder` and `ChainBuilder`.
- Updated tests (`keys=[...]` → `key=[...]`, plus an empty-sequence no-op test) and the README.

## Why this isn't a breaking change

`keys=` was introduced in #66, **after** the v5.0.0 release, so it was never published — folding it into `key=` does not break any released API.

## Validation

- `uv run pytest` (stdlib `re` + `REBULK_REGEX_ENABLED=1` + `REBULK_CHECK_DECLARED_KEYS=1`)
- `uv run ruff check` / `ruff format` / `uv run mypy` — all clean

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)