### PR TITLE
docs: show declaring functional properties for check_keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,21 @@ iterable).
 
 ```
 
+A functional pattern emits its match names dynamically, so they cannot be read
+off the pattern statically. Rather than allowlisting them, declare the names the
+callable emits via `properties` — a `{name: [values]}` mapping `check_keys`
+reads as the names that pattern can produce (the values are unused here). This
+keeps the key statically accounted for instead of silently exempted:
+
+```python
+>>> part = Key('part', int)
+>>> rb = Rebulk().declare_keys(part) \
+...        .functional(lambda string: None, properties={'part': [None]})
+>>> rb.check_keys()
+[]
+
+```
+
 Markers
 =======
 


### PR DESCRIPTION
## Context

`check_keys` (#73) flags declared keys that no built pattern can produce, reading each pattern's `name`, regex group names, and declared `properties`. A **functional** pattern emits its match names dynamically, so they aren't statically detectable.

The docs only steered such names toward `allowed_unused`. But there's a cleaner alternative already supported (and covered by `test_check_keys_honors_pattern_declared_properties`): declare the emitted names via `properties={name: [...]}`, which `check_keys` honors — keeping the key statically accounted for instead of silently exempted.

## Change

Adds a short README paragraph + a verified doctest demonstrating `functional(..., properties={'part': [None]})` so `check_keys()` returns `[]` without allowlisting.

Docs-only; README doctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)