### PR TITLE
fix(key): skip private matches in declared-key value_type check

### DIFF
--- a/rebulk/match.py
+++ b/rebulk/match.py
@@ -925,18 +925,21 @@ class _BaseMatches(MutableSequence):  # type: ignore[type-arg]
         are declared); :class:`~rebulk.rebulk.Rebulk` calls it from ``matches``
         only when :data:`rebulk.debug.CHECK_DECLARED_KEYS` is enabled.
 
-        Three escape hatches keep it free of false positives:
+        Escape hatches keep it free of false positives:
 
         * a ``None`` value (an unmatched / cleared match) is skipped;
         * a ``value=``-mapped match (a hardcoded literal that never went through
           the converter) is skipped — its value is not a ``str -> value_type``
           conversion;
+        * a ``private`` match is skipped — it is internal scaffolding, not an
+          emitted value, and the parent of a ``children=True`` pattern carries
+          the raw matched substring (the formatter only runs on the children);
         * each match is checked on its own scalar value, so a name bound to
           several matches (``children``) is validated element by element.
         """
         for match in self:
             key = self.declared_keys.get(match.name) if match.name else None
-            if key is None or match.has_literal_value:
+            if key is None or match.private or match.has_literal_value:
                 continue
             value = match.value
             if value is None or isinstance(value, key.value_type):

--- a/rebulk/test/test_key.py
+++ b/rebulk/test/test_key.py
@@ -358,6 +358,19 @@ def test_check_declared_keys_skips_none_value() -> None:
     matches.check_declared_keys()  # no raise
 
 
+def test_check_declared_keys_skips_private_parent(check_declared_keys: None) -> None:
+    # The private parent of a children pattern carries the raw matched substring
+    # (only the children are formatted), so it is not an instance of the declared
+    # value_type. Being internal/non-emitted, it must be skipped, not flagged.
+    bonus = Key("bonus", int)
+    bulk = Rebulk().declare_keys(bonus).regex(r"x(\d+)", name="bonus", children=True, private_parent=True)
+
+    matches = bulk.matches("x264")  # private parent value "x264" (str) must not raise
+
+    # only the emitted (non-private) child is validated, and it is the int value.
+    assert [match.value for match in matches if not match.private] == [264]
+
+
 def test_check_declared_keys_skips_value_mapped_literal() -> None:
     # A value=-mapped literal never goes through the converter; it is exempt
     # even when its type differs from the declared value_type.


### PR DESCRIPTION
## Problem

`Matches.check_declared_keys()` (the opt-in declared-key contract check, #72) raised a **false positive** on the **private parent of a `children=True` pattern**.

For a pattern like `x(\d+)` with `private_parent=True` and a declared `Key("bonus", int)`:
- the **child** is formatted → `264` (int), matches the declared type ✓
- the **private parent** keeps the **raw matched substring** `"x264"` (a parent of a children pattern is never run through the formatter) → not an `int` → the check raised `TypeError`.

Private matches are internal scaffolding, not emitted values, so the declared-type contract should not apply to them.

## Fix

Add `match.private` to the escape hatches in `check_declared_keys` (alongside `None` and `value=`-mapped matches). One line + a regression test.

```python
if key is None or match.private or match.has_literal_value:
    continue
```

## How it surfaced

Enabling the check across a large real-world corpus (the motivation for running it in CI, per #72): patterns with `private_parent` raised on their unformatted parent even though the emitted child converted correctly.

## Validation

- `pytest rebulk/test/test_key.py` — 44 passed (incl. new `test_check_declared_keys_skips_private_parent`)
- full suite — 242 passed