### PR TITLE
chore: release rebulk 6.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,10 @@ jobs:
             range="origin/${{ github.base_ref }}..HEAD"
           else
             before="${{ github.event.before }}"
-            if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
+            # No usable "before": a new branch (empty/zero sha) or a force-push
+            # whose "before" commit is now orphaned and unreachable here.
+            if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ] \
+              || ! git cat-file -e "$before^{commit}" 2>/dev/null; then
               range="HEAD~1..HEAD"
             else
               range="$before..${{ github.sha }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    environment: pypi
+
     permissions:
       contents: write   # semantic-release pushes the version commit + tag and creates the GitHub release
       id-token: write   # PyPI trusted publishing (OIDC), no long-lived token needed

--- a/rebulk/loose.py
+++ b/rebulk/loose.py
@@ -5,13 +5,21 @@ Various utilities functions
 
 from __future__ import annotations
 
-from inspect import getfullargspec, isclass
+from functools import lru_cache
+from inspect import getfullargspec as _getfullargspec
+from inspect import isclass
 from typing import TYPE_CHECKING, Any, cast
 
 from .utils import is_iterable
 
 if TYPE_CHECKING:
     from inspect import FullArgSpec
+
+# Validators/formatters/conflict-solvers are stable singletons for a Rebulk instance's lifetime,
+# so their signature introspection is redundant across the many matching-path calls. The set of
+# distinct callables is small and bounded, and getfullargspec is a pure function of its callable,
+# so an unbounded identity cache is safe.
+getfullargspec = lru_cache(maxsize=None)(_getfullargspec)
 
 
 def _constructor(class_: Any) -> Any:


### PR DESCRIPTION
Release rebulk **6.0.1**.

## Changes since 6.0.0

- **perf**: cache `getfullargspec` on the hot matching path (#77, #78) — ~11% faster repeated parses via an `lru_cache` over signature introspection of the stable rule callables.
- ci: run the release job in the `pypi` environment.
- ci: tolerate force-pushed (orphaned) before-ref in the commitizen check.

Merging to `main` triggers semantic-release: version bump → tag → PyPI publish → GitHub release → back-merge to develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ah1tBeqoVa8sM2CP5ibSJQ